### PR TITLE
Add content from welcome page to welcome partial

### DIFF
--- a/layouts/partials/welcome.html
+++ b/layouts/partials/welcome.html
@@ -6,18 +6,7 @@
 
 <div class="row">
   <div class="col-md-4 col-sm-push-8">
-    {{ $.Scratch.Set "subdir" $e.name }}
-    {{ $.Scratch.Set "contentdir" (printf "static/events/%s/" ($.Scratch.Get "subdir")) }}
-    {{ $.Scratch.Set "city" (chomp $e.city) }}
-    {{ range (readDir "static/events") }}
-        {{ if eq .Name ($.Scratch.Get "subdir") }}
-            {{ range (readDir ($.Scratch.Get "contentdir"))}}
-                {{ if eq .Name "logo.png" }}
-                    <img src="{{ printf ("/events/%s/logo.png") ($.Scratch.Get "subdir")}}" class="img-responsive"/>
-                {{ end }}
-            {{ end }}
-        {{ end }}
-    {{ end }}
+    {{ .Content }}
   </div>
     <div class="col-md-8 col-sm-pull-4">
         <h2>DevOpsDays {{ $e.city }}</h2> {{- dateFormat "January 2" $e.startdate -}} - {{- dateFormat "2, 2006" $e.enddate -}}


### PR DESCRIPTION
The styling is not great yet, but it’s there.
This also takes away the whole “try to find the logo and then put itthere if it’s there” nonsense.

Fixes #75

Signed-off-by: Matt Stratton <matt.stratton@gmail.com>