### PR TITLE
Restoring missing city; changing grammar.

### DIFF
--- a/layouts/partials/welcome.html
+++ b/layouts/partials/welcome.html
@@ -19,7 +19,7 @@
             {{- if eq (lower .city) (lower $e.city) -}}
               {{- $.Scratch.Add "past-counter" 1 -}}
               {{- if eq ($.Scratch.Get "past-counter") 1 -}}
-                <i>Past Events in {{ ($.Scratch.Get "city") }}</i><br />
+                <i>Past {{ $e.city }} Events</i><br />
               {{- end -}}
               {{- if ne .startdate $e.startdate -}}
                 <a href = "/events/{{ .name }}">{{ dateFormat "2006" .startdate }}</a> <br />


### PR DESCRIPTION
We were referencing the city name incorrectly to get it to show up in this header.

Also, changing the grammar per https://github.com/devopsdays/devopsdays-theme/issues/61 to better work when we transition to using event groups.