### PR TITLE
Add support for Description to blog posts

### DIFF
--- a/archetypes/blog.md
+++ b/archetypes/blog.md
@@ -1,0 +1,6 @@
++++
+Description = ""
+title = ""
+Author = ""
+
++++

--- a/exampleSite/content/blog/2016-chicago.md
+++ b/exampleSite/content/blog/2016-chicago.md
@@ -1,9 +1,10 @@
 +++
 Categories = []
-Description = ""
+Description = "[DevOpsDays Chicago](https://devopsdays.org/events/2016-chicago) took place on August 30th & 31st at Summit West in beautiful downtown Chicago. A sold-out, diverse crowd gathered for keynotes, presentations, lightning talks, and open spaces to learn, discuss, and promote all things DevOps."
 Tags = []
 date = "2016-12-12T16:31:00-06:00"
 title = "Chicago 2016 in review"
+Author = "Matt Stratton"
 
 +++
 

--- a/layouts/blog/summary.html
+++ b/layouts/blog/summary.html
@@ -1,7 +1,13 @@
 <header>
   <h2><a href='{{ .Permalink }}'> {{ .Title }}</a> </h2>
 </header>
-{{ .Summary }}
+{{ if isset .Params "description" }}
+  {{ if ne .Params.descripton "" }}
+    {{ .Params.description | markdownify }}
+  {{ end }}
+{{ else }}
+  {{ .Summary }}
+{{ end }}
 <footer>
   <a href='{{ .Permalink }}'><nobr>Read more →</nobr></a>
 </footer>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -23,7 +23,13 @@
                   <h2 class="footer-heading">{{ dateFormat "02 January, 2006" .Date }}</h2>
                 {{- end -}}
                 <p class="footer-content">
+                  {{ if isset .Params "description" }}
+                    {{ if ne .Params.descripton "" }}
+                      {{ .Params.description | markdownify }}
+                    {{ end }}
+                  {{ else }}
                     {{ .Summary }}
+                  {{ end }}
                 </p>
               {{- end -}}
 


### PR DESCRIPTION
The proper metadata is also in the archtype for blog now.

Fixes #54

Signed-off-by: Matt Stratton <matt.stratton@gmail.com>