### PR TITLE
Event page

### DIFF
--- a/exampleSite/content/page/events.md
+++ b/exampleSite/content/page/events.md
@@ -1,7 +1,7 @@
 +++
 date = "2015-11-29T00:00:00-06:00"
 title = "devopsdays events"
-type = "events-list"
+type = "events"
 aliases = ["/calendar", "/events/calendar", "/devops-calendar", "/presentations"]
 
 +++

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -15,7 +15,7 @@
                 {{- block "main" . }} {{- end -}}
             </div>
             <div class="col-md-2 pull-md-8">
-                <a href = "/past" class="left-nav-navs">PAST EVENTS</a><br />
+                <a href = "/events" class="left-nav-navs">PAST EVENTS</a><br />
                 {{- partial "future.html" . -}}
             </div>
         </div>

--- a/layouts/events/single.html
+++ b/layouts/events/single.html
@@ -1,0 +1,16 @@
+{{ define "main" }}
+
+{{/* site data query copypasta */}}
+{{ $path := split $.Source.File.Path .Site.Params.pathseperator }}
+{{ $event_slug := index $path 1 }}
+{{ $e :=  (index $.Site.Data.events $event_slug) }}
+{{/* end site data query */}}
+
+<div>
+      {{ .Content }}
+</div>
+
+{{ partial "future.html" . }}
+{{ partial "past.html" . }}
+
+{{ end }}

--- a/layouts/partials/future.html
+++ b/layouts/partials/future.html
@@ -8,6 +8,7 @@
       {{- if ne ($.Scratch.Get "month") (dateFormat "January" .startdate ) -}}
         {{- $.Scratch.Set "month" (dateFormat "January" .startdate ) -}}
         {{- $.Scratch.Set "month-displayed" "false" -}}
+<br />
       {{- end -}}
       {{- if ne ($.Scratch.Get "year-displayed") "true" -}}
         <h3 class="left-nav-year">{{ dateFormat "2006" .startdate }}</h3>

--- a/layouts/partials/past.html
+++ b/layouts/partials/past.html
@@ -1,0 +1,43 @@
+ <!-- The following blocks of comments explains how this list is generated with Hugo.
+If you read this post generation, it will make no sense. see pre generated sources -->
+
+<!-- Scan through a range of years and look in data/events for events during these years.
+If found, store year in "active_years" scratch in order to get back to that year later.
+Also save the event name under scratch with the ID of the scratch equal to the year number.
+
+Chomping .year has the nice effect of turning an int into string. -->
+{{ range seq 2009 2020 }}
+  {{ $r_year := . }}
+  {{ range $.Site.Data.events }}
+  {{ if .startdate }}
+  {{ $my_year := string ((dateFormat "2006" .startdate ))}}
+    {{ if and (eq $my_year (string $r_year)) ( lt (dateFormat "2006-01-02" .startdate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")))  }}
+      {{ $.Scratch.SetInMap "active_years" (print (chomp $my_year)) (print (chomp $my_year)) }}
+      {{ $.Scratch.SetInMap (print (chomp $my_year)) .startdate (.name) }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ end }}
+
+<div class = "row">
+  <div class = "col-md-12">
+    <h2>Past</h2>
+  </div>
+</div>
+<div class = "row">
+  <!-- Now scan through all the years that were marked as active in order to print the headline -->
+  {{ range ($.Scratch.GetSortedMapValues "active_years") }}
+    <div class = "col-md-4">
+      <strong>{{ . }}</strong>
+      <br/>
+        <!-- Finally, scan throug the scratch with the ID of that year and print all the events sorted by startdate
+  Chomping here in order to convert int to string -->
+        {{ range ($.Scratch.GetSortedMapValues (print (chomp .))) }}
+            {{ $.Scratch.Set "citydisplay" (index $.Site.Data.events . "city") }}
+          {{ $friendly := (index $.Site.Data.events . "name") }}
+          <a href="/events/{{ $friendly }}/">{{ $.Scratch.Get "citydisplay" }}</a>
+          <br/>
+        {{ end }}
+      </div>
+      {{ end }}
+    </div>


### PR DESCRIPTION
* Adding the `/events` page much as it was before, only using the much-improved new `future` partial.
* Occam's Razor says our shortest path to a "/past" page is instead just linking the "/events" page.
* Slight fix to layout to prevent the next month's name from being immediately below the previous set of dates:

Before:
![screen shot 2017-02-02 at 11 23 47 am](https://cloud.githubusercontent.com/assets/2104453/22560422/2a088cbc-e93a-11e6-83aa-60881a7cd1b7.png)

After:
![screen shot 2017-02-02 at 11 24 06 am](https://cloud.githubusercontent.com/assets/2104453/22560418/26774a66-e93a-11e6-96b9-9b5aaa4734bb.png)

