### PR TITLE
Moving past events to bottom of column

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -34,8 +34,8 @@
                 {{- block "main" . }} {{- end -}}
             </div>
             <div class="col-md-2 pull-md-8">
-                <a href = "/events" class="left-nav-navs">PAST EVENTS</a><br />
                 {{- partial "future.html" . -}}
+                <a href = "/events" class="left-nav-navs">PAST EVENTS</a><br />
             </div>
         {{ end }}
         </div>


### PR DESCRIPTION
Although "past events" appears another place in this file, that condition doesn't seem to be hit on the main page, and this one does.

Fixes https://github.com/devopsdays/devopsdays-theme/issues/142