### PR TITLE
Changing event twitter to use data file

### DIFF
--- a/layouts/shortcodes/event_twitter.html
+++ b/layouts/shortcodes/event_twitter.html
@@ -1,2 +1,6 @@
-<a href="https://twitter.com/{{ index .Params 0 }}" class="twitter-follow-button" data-show-count="false">Follow @{{ index .Params 0 }}</a>
+{{ $path := split .Page.Source.File.Path .Site.Params.pathseperator }}
+{{ $event_slug := index $path 1 }}
+{{ $e :=  (index .Page.Site.Data.events $event_slug) }}
+
+<a href="https://twitter.com/{{ $e.event_twitter }}" class="twitter-follow-button" data-show-count="false">Follow @{{ $e.event_twitter }}</a>
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>


### PR DESCRIPTION
Related to https://github.com/devopsdays/devopsdays-theme/issues/132 - this means that instead of using whatever param is set, the event_twitter shortcode will use what's in the datafile.

