### PR TITLE
Change the setting in sample new event

### DIFF
--- a/exampleSite/utilities/examples/data/events/yyyy-city.yml
+++ b/exampleSite/utilities/examples/data/events/yyyy-city.yml
@@ -20,7 +20,7 @@ registration_open: "false"
 registration_link: ""
 
 event_logo: "logo.jpg"
-event_logo_square: "logo-square.jpg"
+square_logo_default: "false" # Set to "true" to use the default logo on the homepage instead of logo-square.jpg in your static directory 
 
 # Location
 #


### PR DESCRIPTION
This allows for use of the default square image as an override. Open to bikeshedding as if it should be defaulting to "true" on a new event.