### PR TITLE
Make speaker page backwards-compatible

### DIFF
--- a/layouts/speakers/single.html
+++ b/layouts/speakers/single.html
@@ -66,7 +66,7 @@
   <div class="col-md-12 col-lg-3">
       <img alt = "{{ $s.name }}" src = "/events/{{ $event_slug }}/speakers/{{$fname}}.jpg" class="speakers-page old-speaker">
   </div>
-  <div class= "col-md-12 col-lg-9 old-speaker-bio">
+  <div class= "col-md-12 col-lg-9 old-speaker-bio speakers-page">
      <h3><a href="/events/{{ $event_slug }}/program/{{$fname}}">{{ $s.name }}</a></h3>
      {{ if $s.twitter }} <a href="https://twitter.com/{{ $s.twitter }}">@{{ $s.twitter }}</a><br>{{ end }}
      {{ if $s.website }}Website: <a href="{{ $s.website }}">{{ $s.website }}</a><br>{{ end }}
@@ -86,6 +86,7 @@ img.old-speaker {
 }
 .old-speaker-bio {
   padding-right: 20px;
+  margin-top: 20px;
 }
 </style>
 

--- a/layouts/speakers/single.html
+++ b/layouts/speakers/single.html
@@ -15,6 +15,7 @@
   {{- $speaker_path := split .File.Path .Site.Params.PathSeparator -}}
   {{- $speaker_slug := index $speaker_path 1 -}}
   {{- if eq $speaker_slug $event_slug -}}
+  {{ $.Scratch.Set "speakers-exist" "true" }}
 
   {{ $bio := .Content }}
   {{ $subStr := split $bio " "}}
@@ -55,6 +56,42 @@
 {{- end -}} <!-- end range where $.Site.Pages "Type" "speaker" -->
 
 </div>
+
+<!-- old stuff -->
+{{ if ne ($.Scratch.Get "speakers-exist") "true" }}
+  {{ .Content }}
+
+  {{ range $fname, $s := index .Site.Data.speakers (print (chomp $e.year)) $city_slug }}
+<div class="row">
+  <div class="col-md-12 col-lg-3">
+      <img alt = "{{ $s.name }}" src = "/events/{{ $event_slug }}/speakers/{{$fname}}.jpg" class="speakers-page old-speaker">
+  </div>
+  <div class= "col-md-12 col-lg-9 old-speaker-bio">
+     <h3><a href="/events/{{ $event_slug }}/program/{{$fname}}">{{ $s.name }}</a></h3>
+     {{ if $s.twitter }} <a href="https://twitter.com/{{ $s.twitter }}">@{{ $s.twitter }}</a><br>{{ end }}
+     {{ if $s.website }}Website: <a href="{{ $s.website }}">{{ $s.website }}</a><br>{{ end }}
+     {{ if $s.pronouns }}Pronouns: {{ $s.pronouns }}{{ end }}
+   <br>
+   {{ $s.bio | markdownify }}
+<hr>
+  </div>
+</div>
+
+{{ end }}
+
+<style>
+img.old-speaker {
+  max-width: 250px;
+  height: auto;
+}
+.old-speaker-bio {
+  padding-right: 20px;
+}
+</style>
+
+{{ end }}
+<!-- end oldstuff -->
+
 
 {{ partial "sponsors.html" . }}
 


### PR DESCRIPTION
This change will allow events using the old-style (datafiles) to still have their speakers show up in /speakers on their event.

It is recommended that after this theme is deployed, any in-flight events migrate to the page-style method, but for now, this works.

Fixes #313

Signed-off-by: Matt Stratton <matt.stratton@gmail.com>