### PR TITLE
Set default icons for common event menu options

### DIFF
--- a/exampleSite/data/events/2017-ponyville.yml
+++ b/exampleSite/data/events/2017-ponyville.yml
@@ -23,21 +23,15 @@ nav_elements:
   # - name: propose
   #   url: http://cfp.devopsdayschi.org
   - name: program
-    icon: "book"
   - name: speakers
-    icon: "microphone"
   - name: registration
     icon: "pencil"
   - name: sponsor
-    icon: "money"
   - name: volunteer
     icon: "smile-o"
   - name: location
-    icon: "map-o"
   - name: contact
-    icon: "envelope-o"
   - name: conduct
-    icon: "handshake-o"
 
 team_members:
   - name: "George Bluth"

--- a/layouts/partials/events/event_navbar.html
+++ b/layouts/partials/events/event_navbar.html
@@ -29,7 +29,7 @@
                   {{ if .icon }}
                     <a href = "{{ .url}}"><i class="fa fa-{{.icon}} fa-2x"></i></a>
                   {{ else }}
-                    <a href = "{{ .url}}"><i class="fa fa-plus fa-2x"></i></a>
+                    <a href = "{{ .url}}"><i class="fa fa-external-link fa-2x"></i></a>
                   {{ end }}
                 </span></li>
             {{ else }}
@@ -41,7 +41,25 @@
                   {{ if .icon }}
                     <a href = "/events/{{ $event_slug }}/{{ .name }}"><i class="fa fa-{{ .icon }} fa-2x"></i></a>
                   {{ else }}
+                    {{ if eq .name "registration" }}
+                      <a href = "/events/{{ $event_slug }}/{{ .name }}"><i class="fa fa-user-plus fa-2x"></i></a>
+                    {{ else if eq .name "program" }}
+                      <a href = "/events/{{ $event_slug }}/{{ .name }}"><i class="fa fa-book fa-2x"></i></a>
+                    {{ else if eq .name "speakers" }}
+                      <a href = "/events/{{ $event_slug }}/{{ .name }}"><i class="fa fa-microphone fa-2x"></i></a>
+                    {{ else if eq .name "sponsor" }}
+                      <a href = "/events/{{ $event_slug }}/{{ .name }}"><i class="fa fa-money fa-2x"></i></a>
+                    {{ else if eq .name "contact" }}
+                      <a href = "/events/{{ $event_slug }}/{{ .name }}"><i class="fa fa-envelope-o fa-2x"></i></a>
+                    {{ else if eq .name "conduct" }}
+                      <a href = "/events/{{ $event_slug }}/{{ .name }}"><i class="fa fa-handshake-o fa-2x"></i></a>
+                    {{ else if eq .name "location" }}
+                      <a href = "/events/{{ $event_slug }}/{{ .name }}"><i class="fa fa-map-o fa-2x"></i></a>
+                    {{ else if eq .name "propose" }}
+                      <a href = "/events/{{ $event_slug }}/{{ .name }}"><i class="fa fa-lightbulb-o fa-2x"></i></a>
+                    {{ else }}
                     <a href = "/events/{{ $event_slug }}/{{ .name }}"><i class="fa fa-plus fa-2x"></i></a>
+                   {{ end }}
                   {{ end }}
                 </span>
               </li>


### PR DESCRIPTION
~This is for https://github.com/devopsdays/devopsdays-web/issues/1819 although it won't entirely fix it (I've noted a bug that came to light).~ Update: https://github.com/devopsdays/devopsdays-web/issues/1829 now means that this...

Fixes https://github.com/devopsdays/devopsdays-web/issues/1819

Instead of putting this in every datafile, I'm setting the most common default menu options we create to have customized default icons. Moscow is a good example of having them all visible with the default, although ignore the extraneous plus sign for now - that's the extra welcome link bug:

![screen shot 2017-02-25 at 1 46 07 pm](https://cloud.githubusercontent.com/assets/2104453/23334380/9bb9c134-fb62-11e6-86bb-20e0bdb8518e.png)

I used the lightbulb for `propose` because otherwise anything mic-like I used would be too close to the `speakers` one. I know we used to use that lightbulb for the organizing page, but afaict we aren't using the fa iconset on the site-wide menu anymore, so I think it's safe to re-use it.

Users can override these for existing words or can define custom options with specific icons, as desired. Ponyville added "volunteer" and is using a different icon for "registration" (I'm good with all your other choices, @mattstratton, but a pencil looks like "blog" to me, not like "register for a thing"):

![screen shot 2017-02-25 at 1 50 32 pm](https://cloud.githubusercontent.com/assets/2104453/23334391/e2dc7002-fb62-11e6-8068-9af41bdb21cb.png)

I'm also customizing external links so they're recognizable as such. Salt Lake City has a lot of external links:

![screen shot 2017-02-25 at 1 46 38 pm](https://cloud.githubusercontent.com/assets/2104453/23334393/f70514c6-fb62-11e6-8c45-372dd511719f.png)

I'm hesitant to try to be too opinionated on icons for external links since who knows what they're going to be. I'm open to discussing this (but also would like to encourage the use of on-site choices where it makes sense).
