### PR TITLE
Remove redundant welcome link

### DIFF
--- a/exampleSite/data/events/2010-brazil.yml
+++ b/exampleSite/data/events/2010-brazil.yml
@@ -19,7 +19,6 @@ location: "brazil" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: location
   - name: contact

--- a/exampleSite/data/events/2010-europe.yml
+++ b/exampleSite/data/events/2010-europe.yml
@@ -19,7 +19,6 @@ location: "europe" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: lightning talks
     url: events/2010-europe/lightning-talks # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2010-sydney.yml
+++ b/exampleSite/data/events/2010-sydney.yml
@@ -19,7 +19,6 @@ location: "Sydney" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2010-us.yml
+++ b/exampleSite/data/events/2010-us.yml
@@ -19,7 +19,6 @@ location: "us" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: lightning talks
     url: events/2010-us/lightning-talks

--- a/exampleSite/data/events/2011-bangalore.yml
+++ b/exampleSite/data/events/2011-bangalore.yml
@@ -19,7 +19,6 @@ location: "Bangalore" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: location
   - name: contact

--- a/exampleSite/data/events/2011-boston.yml
+++ b/exampleSite/data/events/2011-boston.yml
@@ -19,7 +19,6 @@ location: "Boston" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2011-goteborg.yml
+++ b/exampleSite/data/events/2011-goteborg.yml
@@ -19,7 +19,6 @@ location: "goteborg" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2011-manila.yml
+++ b/exampleSite/data/events/2011-manila.yml
@@ -19,7 +19,6 @@ location: "Manila" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2011-melbourne.yml
+++ b/exampleSite/data/events/2011-melbourne.yml
@@ -19,7 +19,6 @@ location: "Melbourne" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2011-mountainview.yml
+++ b/exampleSite/data/events/2011-mountainview.yml
@@ -19,7 +19,6 @@ location: "mountainview" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2012-austin.yml
+++ b/exampleSite/data/events/2012-austin.yml
@@ -19,7 +19,6 @@ location: "Austin" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2012-india.yml
+++ b/exampleSite/data/events/2012-india.yml
@@ -19,7 +19,6 @@ location: "india" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2012-italy.yml
+++ b/exampleSite/data/events/2012-italy.yml
@@ -19,7 +19,6 @@ location: "italy" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2012-mountainview.yml
+++ b/exampleSite/data/events/2012-mountainview.yml
@@ -19,7 +19,6 @@ location: "mountainview" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2012-newyork.yml
+++ b/exampleSite/data/events/2012-newyork.yml
@@ -19,7 +19,6 @@ location: "newyork" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2012-tokyo.yml
+++ b/exampleSite/data/events/2012-tokyo.yml
@@ -19,7 +19,6 @@ location: "Tokyo" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2013-amsterdam.yml
+++ b/exampleSite/data/events/2013-amsterdam.yml
@@ -19,7 +19,6 @@ location: "Amsterdam" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2013-atlanta.yml
+++ b/exampleSite/data/events/2013-atlanta.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2013-austin.yml
+++ b/exampleSite/data/events/2013-austin.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2013-barcelona.yml
+++ b/exampleSite/data/events/2013-barcelona.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2013-berlin.yml
+++ b/exampleSite/data/events/2013-berlin.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2013-downunder.yml
+++ b/exampleSite/data/events/2013-downunder.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2013-india.yml
+++ b/exampleSite/data/events/2013-india.yml
@@ -19,7 +19,6 @@ location: "Bangalore" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2013-london-spring.yml
+++ b/exampleSite/data/events/2013-london-spring.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2013-london.yml
+++ b/exampleSite/data/events/2013-london.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2013-mountainview.yml
+++ b/exampleSite/data/events/2013-mountainview.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2013-newyork.yml
+++ b/exampleSite/data/events/2013-newyork.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2013-newzealand.yml
+++ b/exampleSite/data/events/2013-newzealand.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2013-paris.yml
+++ b/exampleSite/data/events/2013-paris.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2013-portland.yml
+++ b/exampleSite/data/events/2013-portland.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2013-telaviv.yml
+++ b/exampleSite/data/events/2013-telaviv.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2013-tokyo.yml
+++ b/exampleSite/data/events/2013-tokyo.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2013-vancouver.yml
+++ b/exampleSite/data/events/2013-vancouver.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2014-amsterdam.yml
+++ b/exampleSite/data/events/2014-amsterdam.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2014-austin.yml
+++ b/exampleSite/data/events/2014-austin.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2014-bangalore.yml
+++ b/exampleSite/data/events/2014-bangalore.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2014-belgium.yml
+++ b/exampleSite/data/events/2014-belgium.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2014-berlin.yml
+++ b/exampleSite/data/events/2014-berlin.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2014-boston.yml
+++ b/exampleSite/data/events/2014-boston.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2014-brisbane.yml
+++ b/exampleSite/data/events/2014-brisbane.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2014-chicago.yml
+++ b/exampleSite/data/events/2014-chicago.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2014-helsinki.yml
+++ b/exampleSite/data/events/2014-helsinki.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2014-ljubljana.yml
+++ b/exampleSite/data/events/2014-ljubljana.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2014-minneapolis.yml
+++ b/exampleSite/data/events/2014-minneapolis.yml
@@ -19,7 +19,6 @@ location: "Minneapolis" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: location
   - name: registration

--- a/exampleSite/data/events/2014-nairobi.yml
+++ b/exampleSite/data/events/2014-nairobi.yml
@@ -19,7 +19,6 @@ location: "Nairobi" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2014-newyork.yml
+++ b/exampleSite/data/events/2014-newyork.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2014-pittsburgh.yml
+++ b/exampleSite/data/events/2014-pittsburgh.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2014-siliconvalley.yml
+++ b/exampleSite/data/events/2014-siliconvalley.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2014-telaviv.yml
+++ b/exampleSite/data/events/2014-telaviv.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2014-toronto.yml
+++ b/exampleSite/data/events/2014-toronto.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2014-vancouver.yml
+++ b/exampleSite/data/events/2014-vancouver.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2014-warsaw.yml
+++ b/exampleSite/data/events/2014-warsaw.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2015-amsterdam.yml
+++ b/exampleSite/data/events/2015-amsterdam.yml
@@ -19,7 +19,6 @@ location: "Amsterdam" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2015-austin.yml
+++ b/exampleSite/data/events/2015-austin.yml
@@ -19,7 +19,6 @@ location: "Austin" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2015-bangalore.yml
+++ b/exampleSite/data/events/2015-bangalore.yml
@@ -19,7 +19,6 @@ location: "Bangalore" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2015-berlin.yml
+++ b/exampleSite/data/events/2015-berlin.yml
@@ -19,7 +19,6 @@ location: "Berlin" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2015-boston.yml
+++ b/exampleSite/data/events/2015-boston.yml
@@ -19,7 +19,6 @@ location: "Boston" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2015-charlotte.yml
+++ b/exampleSite/data/events/2015-charlotte.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2015-chicago.yml
+++ b/exampleSite/data/events/2015-chicago.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2015-denver.yml
+++ b/exampleSite/data/events/2015-denver.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2015-detroit.yml
+++ b/exampleSite/data/events/2015-detroit.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2015-ljubljana.yml
+++ b/exampleSite/data/events/2015-ljubljana.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2015-melbourne.yml
+++ b/exampleSite/data/events/2015-melbourne.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2015-minneapolis.yml
+++ b/exampleSite/data/events/2015-minneapolis.yml
@@ -19,7 +19,6 @@ location: "Minneapolis" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: location
   - name: registration

--- a/exampleSite/data/events/2015-newyork.yml
+++ b/exampleSite/data/events/2015-newyork.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2015-ohio.yml
+++ b/exampleSite/data/events/2015-ohio.yml
@@ -19,7 +19,6 @@ location: "Ohio" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: location
   - name: sponsor
   - name: program

--- a/exampleSite/data/events/2015-paris.yml
+++ b/exampleSite/data/events/2015-paris.yml
@@ -19,7 +19,6 @@ location: "Paris" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2015-pittsburgh.yml
+++ b/exampleSite/data/events/2015-pittsburgh.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2015-siliconvalley.yml
+++ b/exampleSite/data/events/2015-siliconvalley.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2015-singapore.yml
+++ b/exampleSite/data/events/2015-singapore.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2015-telaviv.yml
+++ b/exampleSite/data/events/2015-telaviv.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2015-toronto.yml
+++ b/exampleSite/data/events/2015-toronto.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2015-warsaw.yml
+++ b/exampleSite/data/events/2015-warsaw.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2015-washington-dc.yml
+++ b/exampleSite/data/events/2015-washington-dc.yml
@@ -19,7 +19,6 @@ location: "yourlocation" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2016-amsterdam.yml
+++ b/exampleSite/data/events/2016-amsterdam.yml
@@ -112,7 +112,6 @@ sponsor_levels:
     label: Community
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: workshops
 #  - name: propose

--- a/exampleSite/data/events/2016-atlanta.yml
+++ b/exampleSite/data/events/2016-atlanta.yml
@@ -13,7 +13,6 @@ location: "Georgia Tech Historic Academy of Medicine" # The name of your locatio
 
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: location
   - name: program
   - name: registration

--- a/exampleSite/data/events/2016-austin.yml
+++ b/exampleSite/data/events/2016-austin.yml
@@ -12,7 +12,6 @@ coordinates: "30.2500, -97.7500" # The corrodinates of your venue. Get Latitude 
 location: "Austin" # The name of your location
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: sponsor
   - name: contact
   - name: conduct

--- a/exampleSite/data/events/2016-bangalore.yml
+++ b/exampleSite/data/events/2016-bangalore.yml
@@ -19,7 +19,6 @@ location: "Bangalore" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: propose
 #  - name: program
   - name: devopsdaysindia.org

--- a/exampleSite/data/events/2016-berlin.yml
+++ b/exampleSite/data/events/2016-berlin.yml
@@ -12,7 +12,6 @@ coordinates: "52.524332,13.389849" # The corrodinates of your venue. Get Latitud
 location: "Kalkscheune Berlin" # The name of your location
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: speakers
   - name: program
   - name: location

--- a/exampleSite/data/events/2016-boise.yml
+++ b/exampleSite/data/events/2016-boise.yml
@@ -19,7 +19,6 @@ location: "Boise Centre" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
 #  - name: propose
   - name: speakers

--- a/exampleSite/data/events/2016-boston.yml
+++ b/exampleSite/data/events/2016-boston.yml
@@ -19,7 +19,6 @@ location: "Boston Park Plaza" # Defaults to city, but you can make it the venue 
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: propose
   - name: program
   - name: speakers

--- a/exampleSite/data/events/2016-brasilia.yml
+++ b/exampleSite/data/events/2016-brasilia.yml
@@ -20,7 +20,6 @@ location: "Brasília/DF, Brazil" # Defaults to city, but you can make it the ven
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: speakers
 #  - name: propose

--- a/exampleSite/data/events/2016-capetown.yml
+++ b/exampleSite/data/events/2016-capetown.yml
@@ -19,7 +19,6 @@ location: "Hilton Doubletree, Woodstock, Cape Town" # Defaults to city, but you 
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: speakers
   - name: propose

--- a/exampleSite/data/events/2016-chicago.yml
+++ b/exampleSite/data/events/2016-chicago.yml
@@ -13,7 +13,6 @@ location: "Summit West"
 newnav: "yes"
 # navigationelements: ["welcome", "contact", "location", "program", "propose", "proposals", "conduct", "sponsor"]
 nav_elements:
-  - name: welcome
   # - name: propose
   #   url: http://cfp.devopsdayschi.org
   - name: program

--- a/exampleSite/data/events/2016-cuba.yml
+++ b/exampleSite/data/events/2016-cuba.yml
@@ -19,7 +19,6 @@ location: "Universidad de las Ciencias Informáticas" # Defaults to city, but yo
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: offical website
 #    url: https://devopsdayscuba.eventos.uci.cu/
 #  - name: program

--- a/exampleSite/data/events/2016-dallas.yml
+++ b/exampleSite/data/events/2016-dallas.yml
@@ -12,7 +12,6 @@ coordinates: "32.7767, -96.7970" # The corrodinates of your venue. Get Latitude 
 location: "Grapevine Convention Center, 1209 S. Main Street, Grapevine, TX 76051" # The name of your location
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: contact
   - name: location
   - name: program

--- a/exampleSite/data/events/2016-denver.yml
+++ b/exampleSite/data/events/2016-denver.yml
@@ -12,7 +12,6 @@ coordinates: "39.739236, -104.990251" # The corrodinates of your venue. Get Lati
 location: "Denver" # The name of your location
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: contact
   - name: sponsor
   - name: speakers

--- a/exampleSite/data/events/2016-detroit.yml
+++ b/exampleSite/data/events/2016-detroit.yml
@@ -12,7 +12,6 @@ coordinates: "42.331034, -83.046382" # The corrodinates of your venue. Get Latit
 location: " A. Alfred Taubman Center for Design Education, College for Creative Studies" # The name of your location
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: contact
   - name: location
   - name: registration

--- a/exampleSite/data/events/2016-ghent.yml
+++ b/exampleSite/data/events/2016-ghent.yml
@@ -19,7 +19,6 @@ location: "Zebrastraat" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
 #  - name: propose
   - name: speakers

--- a/exampleSite/data/events/2016-istanbul.yml
+++ b/exampleSite/data/events/2016-istanbul.yml
@@ -12,7 +12,6 @@ coordinates: "41.110065,29.041329" # The corrodinates of your venue. Get Latitud
 location: "Borsa İstanbul Conference Room" # The name of your location
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: location
   - name: program
   - name: propose

--- a/exampleSite/data/events/2016-kansascity.yml
+++ b/exampleSite/data/events/2016-kansascity.yml
@@ -19,7 +19,6 @@ location: "Musical Theater Heritage" # Defaults to city, but you can make it the
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: speakers
   - name: location

--- a/exampleSite/data/events/2016-kiel.yml
+++ b/exampleSite/data/events/2016-kiel.yml
@@ -8,7 +8,6 @@ enddate: 2016-05-13
 coordinates: "54.3233, 10.1228"
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: location
   - name: registration

--- a/exampleSite/data/events/2016-london.yml
+++ b/exampleSite/data/events/2016-london.yml
@@ -13,7 +13,6 @@ location: "location" # The name of your location
 
 
 nav_elements:
-  - name: welcome
   - name: program
   - name: hackathon
   - name: presenters

--- a/exampleSite/data/events/2016-losangeles-1day.yml
+++ b/exampleSite/data/events/2016-losangeles-1day.yml
@@ -19,7 +19,6 @@ location: "Los Angeles" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: propose
   - name: program
   - name: location

--- a/exampleSite/data/events/2016-madison.yml
+++ b/exampleSite/data/events/2016-madison.yml
@@ -19,7 +19,6 @@ location: "Overture Center for the Arts" # Defaults to city, but you can make it
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: speakers
 #  - name: propose

--- a/exampleSite/data/events/2016-minneapolis.yml
+++ b/exampleSite/data/events/2016-minneapolis.yml
@@ -12,7 +12,6 @@ coordinates: "44.972610,-93.272960" # The corrodinates of your venue. Get Latitu
 location: "Downtown Minneapolis Hilton" # The name of your location
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: speakers
   - name: location

--- a/exampleSite/data/events/2016-nashville.yml
+++ b/exampleSite/data/events/2016-nashville.yml
@@ -12,7 +12,6 @@ coordinates: "36.160606, -86.7746752" # The corrodinates of your venue. Get Lati
 location: "aVenue" # The name of your location
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: registration
     url: https://www.eventbrite.com/e/devopsdays-nashville-2016-tickets-23942633060
   - name: location

--- a/exampleSite/data/events/2016-newyork.yml
+++ b/exampleSite/data/events/2016-newyork.yml
@@ -12,7 +12,6 @@ coordinates: "40.7127, -74.0059" # The coordinates of your venue. Get Latitude a
 location: "Microsoft Technology Center" # The name of your location
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: contact
   - name: location
   - name: speakers 

--- a/exampleSite/data/events/2016-newzealand.yml
+++ b/exampleSite/data/events/2016-newzealand.yml
@@ -19,7 +19,6 @@ location: "BNZ Harbour Quays, 60 Waterloo Quay, Wellington" # Defaults to city, 
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: propose
 #    url: https://www.papercall.io/devopsdays-wellington # The url setting is optional, and only if you want the navigation to link off-site
   - name: location

--- a/exampleSite/data/events/2016-ohio.yml
+++ b/exampleSite/data/events/2016-ohio.yml
@@ -12,7 +12,6 @@ coordinates: "40.038877, -82.874830" # The corrodinates of your venue. Get Latit
 location: "Shadow Box" # The name of your location
 #navigationelements: ["welcome", "contact", "location", "program", "propose", "proposals", "registration", "conduct", "sponsor"] # List of pages you want to show up in the navigation of your page. Remove any that aren't relevent yet.
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: videos
     url: "https://www.youtube.com/channel/UCUOAwmKgK1frEKoa-KOrYxg"
   - name: contact

--- a/exampleSite/data/events/2016-oslo.yml
+++ b/exampleSite/data/events/2016-oslo.yml
@@ -19,7 +19,6 @@ location: "Gamle Museet / The Old Museum" # Defaults to city, but you can make i
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: speakers
   - name: propose

--- a/exampleSite/data/events/2016-paris.yml
+++ b/exampleSite/data/events/2016-paris.yml
@@ -18,7 +18,6 @@ location: "Le Grand Rex" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2016-philadelphia.yml
+++ b/exampleSite/data/events/2016-philadelphia.yml
@@ -12,7 +12,6 @@ coordinates: "39.9500, -75.1667" # The corrodinates of your venue. Get Latitude 
 location: "Chemical Heritage Foundation" # The name of your location
 
 nav_elements:
-  - name: welcome
   - name: contact
   - name: program
   - name: speakers

--- a/exampleSite/data/events/2016-portland.yml
+++ b/exampleSite/data/events/2016-portland.yml
@@ -11,7 +11,6 @@ cfp_date_announce: 2016-07-01
 coordinates: "45.528562, -122.663028" # The corrodinates of your venue. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
 location: "The Oregon Convention Center" # The name of your location
 nav_elements:
-  - name: welcome
   - name: location
   - name: registration
     url: https://devopsdayspdx2016.busyconf.com/bookings/new

--- a/exampleSite/data/events/2016-raleigh.yml
+++ b/exampleSite/data/events/2016-raleigh.yml
@@ -11,7 +11,6 @@ cfp_date_announce: 2016-07-15
 coordinates: "35.779590,-78.638179" # The corrodinates of your venue. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
 location: "McKimmon Conference & Training Center"
 nav_elements: # List of pages you want to show up in the navigation of your page. Remove any that aren't relevent yet.
-  - name: welcome
   - name: program
   - name: speakers
   - name: sponsor

--- a/exampleSite/data/events/2016-saltlakecity.yml
+++ b/exampleSite/data/events/2016-saltlakecity.yml
@@ -12,7 +12,6 @@ coordinates: "40.7631, -111.8828" # The corrodinates of your venue. Get Latitude
 location: "Church and State" # The name of your location
 newnav: "yes"
 nav_elements:
-  - name: welcome
   - name: sponsor
     url: http://slcdevopsdays.org/our-sponsors/
   - name: contact

--- a/exampleSite/data/events/2016-seattle.yml
+++ b/exampleSite/data/events/2016-seattle.yml
@@ -80,7 +80,6 @@ sponsor_levels: # In this section, list the level of sponsorships and the label 
     label: Community
 
 nav_elements: # List of pages you want to show up in the navigation of your page. Remove any that aren't relevent yet.
-  - name: welcome
   - name: contact
   - name: location
   - name: program

--- a/exampleSite/data/events/2016-siliconvalley.yml
+++ b/exampleSite/data/events/2016-siliconvalley.yml
@@ -85,7 +85,6 @@ sponsor_levels: # In this section, list the level of sponsorships and the label 
     label: Community
 
 nav_elements: # List of pages you want to show up in the navigation of your page. Remove any that aren't relevent yet.
-  - name: welcome
   - name: contact
   - name: location
   - name: registration

--- a/exampleSite/data/events/2016-singapore.yml
+++ b/exampleSite/data/events/2016-singapore.yml
@@ -13,7 +13,6 @@ location: "Raffles City Convention Centre, Singapore" # The name of your locatio
 # List of pages you want to show up in the navigation of your page. Remove any that aren't relevent yet.
 newnav: "yes"
 nav_elements:
-  - name: welcome
   - name: speakers
   - name: program
   - name: location

--- a/exampleSite/data/events/2016-sydney.yml
+++ b/exampleSite/data/events/2016-sydney.yml
@@ -17,7 +17,6 @@ location: "Sydney" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: speakers
   #- name: propose

--- a/exampleSite/data/events/2016-telaviv.yml
+++ b/exampleSite/data/events/2016-telaviv.yml
@@ -19,7 +19,6 @@ location: "Tel Aviv Convention Center" # Defaults to city, but you can make it t
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
     # url: http://goo.gl/forms/UBAWiffHptWZENGK2 # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2016-toronto.yml
+++ b/exampleSite/data/events/2016-toronto.yml
@@ -12,7 +12,6 @@ coordinates: "43.7000, -79.4000" # The corrodinates of your venue. Get Latitude 
 location: "Glenn Gould Studio" # The name of your location
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: propose
   - name: program
   - name: location

--- a/exampleSite/data/events/2016-vancouver.yml
+++ b/exampleSite/data/events/2016-vancouver.yml
@@ -12,7 +12,6 @@ coordinates: "49.2827, -123.1207" # The corrodinates of your venue. Get Latitude
 location: "location" # The name of your location
 
 nav_elements:
-  - name: welcome
   - name: program
   - name: location
   - name: livestream

--- a/exampleSite/data/events/2016-warsaw.yml
+++ b/exampleSite/data/events/2016-warsaw.yml
@@ -18,7 +18,6 @@ location: "Warsaw" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
   - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2016-washington-dc.yml
+++ b/exampleSite/data/events/2016-washington-dc.yml
@@ -12,7 +12,6 @@ coordinates: "38.8011545,-77.0659376" # The corrodinates of your venue. Get Lati
 location: "US Patent and Trademark Office" # The name of your location
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: register
     url: https://devopsdaysdc2016.busyconf.com/bookings/new
   # - name: propose

--- a/exampleSite/data/events/2017-amsterdam.yml
+++ b/exampleSite/data/events/2017-amsterdam.yml
@@ -27,7 +27,6 @@ organizer_email: "organizers-amsterdam-2017@devopsdays.org" # Put your organizer
 proposal_email: "organizers-amsterdam-2017@devopsdays.org" # Put your proposal email address here
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
   - name: propose
     url: https://devopsdays.typeform.com/to/hbkd2j

--- a/exampleSite/data/events/2017-atlanta.yml
+++ b/exampleSite/data/events/2017-atlanta.yml
@@ -21,7 +21,6 @@ location: "Atlanta" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
   - name: propose
     url: https://www.papercall.io/devopsdaysatl2017 # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2017-austin.yml
+++ b/exampleSite/data/events/2017-austin.yml
@@ -20,7 +20,6 @@ location: "Austin" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: sponsor
   - name: contact
   - name: conduct

--- a/exampleSite/data/events/2017-baltimore.yml
+++ b/exampleSite/data/events/2017-baltimore.yml
@@ -19,7 +19,6 @@ coordinates: "39.286400, -76.605606" # The coordinates of your city. Get Latitud
 location: "Baltimore" # Defaults to city, but you can make it the venue name.
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
     url: http://devopsdaysbaltimore2017.busyconf.com/schedule
   - name: propose

--- a/exampleSite/data/events/2017-beijing.yml
+++ b/exampleSite/data/events/2017-beijing.yml
@@ -21,7 +21,6 @@ location: "Sofitel Wanda Beijing hotel" # Defaults to city, but you can make it 
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2017-cape-town.yml
+++ b/exampleSite/data/events/2017-cape-town.yml
@@ -21,7 +21,6 @@ location: "Hilton Doubletree, Woodstock, Cape Town" # Defaults to city, but you 
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2017-charlotte.yml
+++ b/exampleSite/data/events/2017-charlotte.yml
@@ -21,7 +21,6 @@ location: "Mint Museum Uptown" # Defaults to city, but you can make it the venue
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
     url: https://www.papercall.io/dod-clt

--- a/exampleSite/data/events/2017-chicago.yml
+++ b/exampleSite/data/events/2017-chicago.yml
@@ -21,7 +21,6 @@ location: "Holiday Inn Mart Plaza" # Defaults to city, but you can make it the v
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2017-dallas.yml
+++ b/exampleSite/data/events/2017-dallas.yml
@@ -23,7 +23,6 @@ location: "Dallas / Ft. Worth" # Defaults to city, but you can make it the venue
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2017-denver.yml
+++ b/exampleSite/data/events/2017-denver.yml
@@ -14,7 +14,6 @@ coordinates: "39.739236, -104.990251" # The corrodinates of your venue. Get Lati
 location: "Denver" # The name of your location
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: sponsor
   - name: propose
   - name: contact

--- a/exampleSite/data/events/2017-detroit.yml
+++ b/exampleSite/data/events/2017-detroit.yml
@@ -22,7 +22,6 @@ location: "A. Alfred Taubman Center for Design Education, College for Creative S
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2017-edinburgh.yml
+++ b/exampleSite/data/events/2017-edinburgh.yml
@@ -19,7 +19,6 @@ location: "Edinburgh" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2017-hartford.yml
+++ b/exampleSite/data/events/2017-hartford.yml
@@ -19,7 +19,6 @@ location: "Hartford" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2017-hoofington.yml
+++ b/exampleSite/data/events/2017-hoofington.yml
@@ -14,7 +14,6 @@ location: "Hoofington Palace"
 newnav: "yes"
 # navigationelements: ["welcome", "contact", "location", "program", "propose", "proposals", "conduct", "sponsor"]
 nav_elements:
-  - name: welcome
   # - name: propose
   #   url: http://cfp.devopsdayschi.org
   - name: program

--- a/exampleSite/data/events/2017-indianapolis.yml
+++ b/exampleSite/data/events/2017-indianapolis.yml
@@ -21,7 +21,6 @@ location: "Indianapolis" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2017-istanbul.yml
+++ b/exampleSite/data/events/2017-istanbul.yml
@@ -21,7 +21,6 @@ location: "Dedeman Bostanci Istanbul" # Defaults to city, but you can make it th
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
   - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2017-kansascity.yml
+++ b/exampleSite/data/events/2017-kansascity.yml
@@ -18,7 +18,6 @@ coordinates: "39.082920, -94.582451" # The coordinates of your city. Get Latitud
 #location: "Musical Theater Heritage" # Defaults to city, but you can make it the venue name.
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
 #  - name: speakers
 #  - name: location

--- a/exampleSite/data/events/2017-london.yml
+++ b/exampleSite/data/events/2017-london.yml
@@ -19,7 +19,6 @@ location: "London" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2017-los-angeles.yml
+++ b/exampleSite/data/events/2017-los-angeles.yml
@@ -18,7 +18,6 @@ location: "Pasadena Convention Center" # Defaults to city, but you can make it t
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: location

--- a/exampleSite/data/events/2017-madison.yml
+++ b/exampleSite/data/events/2017-madison.yml
@@ -18,7 +18,6 @@ location: "Madison" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2017-minneapolis.yml
+++ b/exampleSite/data/events/2017-minneapolis.yml
@@ -17,7 +17,6 @@ coordinates: "44.972610,-93.272960"
 location: "Minneapolis"
 
 nav_elements:
-  - name: welcome
 #  - name: program
 #  - name: speakers
   - name: propose

--- a/exampleSite/data/events/2017-moscow.yml
+++ b/exampleSite/data/events/2017-moscow.yml
@@ -21,7 +21,6 @@ location: "Moscow" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
   - name: speakers

--- a/exampleSite/data/events/2017-ohio.yml
+++ b/exampleSite/data/events/2017-ohio.yml
@@ -12,7 +12,6 @@ cfp_date_announce: ""
 coordinates: "40.038877, -82.874830" # The corrodinates of your venue. Get Latitude and Longitude of a Point: http://itouchmap.com/latlong.html
 location: "" # The name of your location
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: contact
   - name: conduct
   - name: sponsor

--- a/exampleSite/data/events/2017-oslo.yml
+++ b/exampleSite/data/events/2017-oslo.yml
@@ -27,7 +27,6 @@ location: "Gamle Museet / The Old Museum" # Defaults to city, but you can make i
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
 #  - name: speakers
   - name: propose

--- a/exampleSite/data/events/2017-paris.yml
+++ b/exampleSite/data/events/2017-paris.yml
@@ -19,7 +19,6 @@ location: "Paris" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2017-portland.yml
+++ b/exampleSite/data/events/2017-portland.yml
@@ -21,7 +21,6 @@ location: "Portland" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2017-raleigh.yml
+++ b/exampleSite/data/events/2017-raleigh.yml
@@ -21,7 +21,6 @@ location: "McKimmon Conference & Training Center" # Defaults to city, but you ca
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2017-saint-louis.yml
+++ b/exampleSite/data/events/2017-saint-louis.yml
@@ -19,7 +19,6 @@ location: "Saint Louis" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
 #  - name: propose
 #    url: https://trello.com/b/qtP2nsVm/presentations # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2017-salt-lake-city.yml
+++ b/exampleSite/data/events/2017-salt-lake-city.yml
@@ -21,7 +21,6 @@ location: "Noah's Event Venue" # Defaults to city, but you can make it the venue
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
   - name: propose
     url: https://www.papercall.io/slc-dev-ops-days

--- a/exampleSite/data/events/2017-seattle.yml
+++ b/exampleSite/data/events/2017-seattle.yml
@@ -21,7 +21,6 @@ location: "Seattle" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2017-stockholm.yml
+++ b/exampleSite/data/events/2017-stockholm.yml
@@ -21,7 +21,6 @@ location: "Stockholm, Ballroom 12" # Defaults to city, but you can make it the v
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
   - name: propose
     #url: https://devopsdayssthlm.typeform.com/to/eMaXqd

--- a/exampleSite/data/events/2017-tokyo.yml
+++ b/exampleSite/data/events/2017-tokyo.yml
@@ -20,7 +20,6 @@ location: "大崎ブライトコアホール" # Defaults to city, but you can ma
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
   - name: propose
     url: https://confengine.com/devopsdays-tokyo-2017

--- a/exampleSite/data/events/2017-toronto.yml
+++ b/exampleSite/data/events/2017-toronto.yml
@@ -21,7 +21,6 @@ location: "Glenn Gould Studio" # The name of your location
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
   - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2017-vancouver.yml
+++ b/exampleSite/data/events/2017-vancouver.yml
@@ -22,7 +22,6 @@ location: "Vancouver" # Defaults to city, but you can make it the venue name.
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
   - name: program
   - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2017-washington-dc.yml
+++ b/exampleSite/data/events/2017-washington-dc.yml
@@ -20,7 +20,6 @@ location: "Washington, DC" # Defaults to city, but you can make it the venue nam
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: program
 #  - name: propose
 #    url: http://mycfp.com # The url setting is optional, and only if you want the navigation to link off-site

--- a/exampleSite/data/events/2017-zurich.yml
+++ b/exampleSite/data/events/2017-zurich.yml
@@ -21,7 +21,6 @@ location: "Zürich Winterthur" # Defaults to city, but you can make it the venue
 #
 
 nav_elements: # List of pages you want to show up in the navigation of your page.
-  - name: welcome
 #  - name: talks
   - name: speakers
 # - name: program


### PR DESCRIPTION
This is to let us preview what https://github.com/devopsdays/devopsdays-web/issues/1829 will mean to the site. I think we probably want see this change in place on the test site now and redo it whenever we refresh content, so as to keep the test site looking the way we expect the production site to end up. The one-liner in that referenced issue means it's trivial to do this again.

Because this is only really noticeable as a problem once https://github.com/devopsdays/devopsdays-theme/pull/322 is merged in, it's probably fine to merge it whenever you want but definitely have it merged before or in close proximity to that one.