### PR TITLE
move past event back to top; ensure consistent name.

### DIFF
--- a/exampleSite/content/page/events.md
+++ b/exampleSite/content/page/events.md
@@ -2,7 +2,7 @@
 date = "2015-11-29T00:00:00-06:00"
 title = "devopsdays events"
 type = "events"
-aliases = ["/calendar", "/events/calendar", "/devops-calendar", "/presentations"]
+aliases = ["/calendar", "/events/calendar", "/devops-calendar", "/presentations", "/past"]
 
 +++
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -24,7 +24,7 @@
                   {{- block "main" . }} {{- end -}}
               </div>
               <div class="col-md-2 pull-md-8">
-                  <a href = "/past" class="left-nav-navs">PAST EVENTS</a><br />
+                  <a href = "/events" class="left-nav-navs">PAST EVENTS</a><br />
                   {{- partial "future.html" . -}}
               </div>
             {{ end }}
@@ -34,8 +34,8 @@
                 {{- block "main" . }} {{- end -}}
             </div>
             <div class="col-md-2 pull-md-8">
-                {{- partial "future.html" . -}}
                 <a href = "/events" class="left-nav-navs">PAST EVENTS</a><br />
+                {{- partial "future.html" . -}}
             </div>
         {{ end }}
         </div>


### PR DESCRIPTION
I had moved the past events list to the bottom (https://github.com/devopsdays/devopsdays-theme/issues/142) which we had wanted for reasons I cannot recall, but it makes better chronological sense on top. And since I left it inconsistent, that's why the /blog page had it at the bottom when other site-wide pages had it at the top.