### PR TITLE
Only show month if needed; use colon for clarity

### DIFF
--- a/layouts/partials/future.html
+++ b/layouts/partials/future.html
@@ -19,13 +19,20 @@
         {{- $.Scratch.Set "month-displayed" "true" -}}
       {{- end -}}
       {{- if ne .startdate .enddate }}
+        {{- if eq (dateFormat "January" .startdate) (dateFormat "January" .enddate ) -}}
+          <a href = "/events/{{ .name }}/" class = "left-nav-event">
+        {{ dateFormat "Jan 2" .startdate }} - {{ dateFormat "2" .enddate }}:
+        {{ .city }}
+          </a><br />
+        {{- else -}}
       <a href = "/events/{{ .name }}/" class = "left-nav-event">
-        {{ dateFormat "Jan 2" .startdate }} - {{ dateFormat "Jan 2" .enddate }}
+        {{ dateFormat "Jan 2" .startdate }} - {{ dateFormat "Jan 2" .enddate }}:
         {{ .city }}
       </a><br />
+        {{- end -}}
       {{- else -}}
       <a href = "/events/{{ .name }}/" class = "left-nav-event">
-        {{ dateFormat "Jan 2" .startdate }}
+        {{ dateFormat "Jan 2" .startdate }}:
         {{ .city }}
       </a><br />
       {{- end -}}


### PR DESCRIPTION
Trying to make the list of dates less cluttered and easier to read.

Left: the current setup. Right: my proposed edit.

![screen shot 2017-02-26 at 9 07 16 pm](https://cloud.githubusercontent.com/assets/2104453/23347457/1f10e354-fc68-11e6-9112-4c4ec7f6062e.png)
