### PR TITLE
Make organizer image alt tags have the person’s name

### DIFF
--- a/layouts/shortcodes/list_organizers.html
+++ b/layouts/shortcodes/list_organizers.html
@@ -13,7 +13,7 @@
           <div class = "card" style="max-width: 300px;padding-left:0px;padding-right:0px">
             <h3 class = "card-header">{{ .name }}</h3>
             {{ if .image }}
-              <img class="card-img-top organizer-image" src="/events/{{$event_slug}}/organizers/{{.image}}" alt="Card image cap">
+              <img class="card-img-top organizer-image" src="/events/{{$event_slug}}/organizers/{{.image}}" alt="{{ .name }}">
             {{ end }}
             <div class = "card-block">
               {{ if .employer }}


### PR DESCRIPTION
Fixes #388

Signed-off-by: Matt Stratton <matt.stratton@gmail.com>