### PR TITLE
Add support for event-specific google analytics

### DIFF
--- a/config.codekit3
+++ b/config.codekit3
@@ -8065,6 +8065,12 @@
 		"oAP": "\/layouts\/partials\/global_navbar.html",
 		"oF": 0
 		},
+	"\/layouts\/partials\/google_analytics.html": {
+		"ft": 8192,
+		"oA": 2,
+		"oAP": "\/layouts\/partials\/google_analytics.html",
+		"oF": 0
+		},
 	"\/layouts\/partials\/head.html": {
 		"ft": 8192,
 		"oA": 2,
@@ -9667,7 +9673,7 @@
 		},
 	"\/static\/img\/sharing.jpg": {
 		"ft": 16384,
-		"iS": 125862,
+		"iS": 497434,
 		"oA": 1,
 		"oAP": "\/static\/img\/sharing.jpg",
 		"oF": 0,

--- a/exampleSite/data/events/2017-chicago.yml
+++ b/exampleSite/data/events/2017-chicago.yml
@@ -15,6 +15,7 @@ registration_open: "false"
 registration_link: ""
 cfp_open: "false"
 cfp_link: ""
+ga_tracking_id: "UA-74738648-1"
 
 # Location
 #

--- a/layouts/partials/google_analytics.html
+++ b/layouts/partials/google_analytics.html
@@ -1,0 +1,19 @@
+<!-- Google Analytics -->
+<script>
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga('create', '{{ $.Site.GoogleAnalytics }}', 'auto');
+ga('send', 'pageview');
+{{ if or (eq .Type "welcome") (eq .Type "event") (eq .Type "speaker") (eq .Type "speakers") (eq .Type "talk") (eq .Type "program")}}
+  {{ $path := split $.Source.File.Path .Site.Params.PathSeparator }}
+  {{ $event_slug := index $path 1 }}
+  {{ $e :=  (index $.Site.Data.events $event_slug) }}
+  {{ if $e.ga_tracking_id }}
+    {{ if ne $e.ga_tracking_id "" }}
+      ga('create', '{{$e.ga_tracking_id}}', 'auto', 'clientTracker');
+      ga('clientTracker.send', 'pageview');
+    {{ end }}
+  {{ end }}
+{{ end }}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+<!-- End Google Analytics -->

--- a/layouts/partials/head_includes.html
+++ b/layouts/partials/head_includes.html
@@ -1,3 +1,4 @@
+{{ partial "google_analytics.html" . }}
 <link href="/css/site.css" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700" rel="stylesheet">
 <link href="/css/googlemaps.css" rel="stylesheet">
@@ -39,5 +40,3 @@
 {{ end }}
 
 <!-- <link rel="alternate" type="application/rss+xml" title="devopsdays RSS Feed" href="{{ $.Site.Params.weburl }}/blog/feed/"> -->
-
-{{ template "_internal/google_analytics_async.html" . }}


### PR DESCRIPTION
This allows the use of specifying a `ga_tracking_id` field in the datafile which will send the pageviews of just that particular event to that GA tracking location.

Fixes #414

Signed-off-by: Matt Stratton <matt.stratton@gmail.com>