### PR TITLE
Removing usage of $.Now.Format in partials

### DIFF
--- a/layouts/events/single.html
+++ b/layouts/events/single.html
@@ -14,7 +14,7 @@
   {{ $.Scratch.Set "close-tag" "false" }}
 {{- range sort $.Site.Data.events "startdate" -}}
   {{- if .startdate -}}
-    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) -}}
+    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) -}}
       {{- if ne ($.Scratch.Get "year") (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year" (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year-displayed" "false" -}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -12,7 +12,7 @@
     <div class="row">
         {{- range sort $.Site.Data.events "startdate" -}}
         {{- if .startdate -}}
-        {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) -}}
+        {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) -}}
         {{ $.Scratch.Set "city" .city }}
         {{ $.Scratch.Set "year" .year }}
         {{ $.Scratch.Set "logo" "unset" }}

--- a/layouts/partials/about.html
+++ b/layouts/partials/about.html
@@ -1,6 +1,6 @@
 {{- range sort $.Site.Data.events "startdate" -}}
   {{- if .startdate -}}
-    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) -}}
+    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) -}}
       {{- if ne ($.Scratch.Get "year") (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year" (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year-displayed" "false" -}}

--- a/layouts/partials/events/cta.html
+++ b/layouts/partials/events/cta.html
@@ -27,7 +27,7 @@
     {{ else }}
       {{ if $e.startdate }}
         {{ if $e.registration_date_start }}
-          {{- if and (ge (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) (dateFormat "2006-01-02" $e.registration_date_start)) (le (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) (dateFormat "2006-01-02" $e.registration_date_end)) }}
+          {{- if and (ge (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) (dateFormat "2006-01-02" $e.registration_date_start)) (le (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) (dateFormat "2006-01-02" $e.registration_date_end)) }}
             {{ if $e.registration_link }}
               {{ if eq $e.registration_link "" }}
                 {{ $.Scratch.Set "registration_link" (printf "/events/%s/propose" $event_slug)}}
@@ -57,7 +57,7 @@
   <!-- propose button -->
   {{ if $e.startdate }}
     {{ if $e.cfp_date_start }}
-      {{- if and (ge (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) (dateFormat "2006-01-02" $e.cfp_date_start)) (le (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) (dateFormat "2006-01-02" $e.cfp_date_end)) }}
+      {{- if and (ge (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) (dateFormat "2006-01-02" $e.cfp_date_start)) (le (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) (dateFormat "2006-01-02" $e.cfp_date_end)) }}
         {{ if $e.cfp_link }}
           {{ if eq $e.cfp_link "" }}
             {{ $.Scratch.Set "cfp_link" (printf "/events/%s/propose" $event_slug)}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -47,7 +47,7 @@
       <h3 class="footer-nav">CFP OPEN</h3>
       {{ range sort $.Site.Data.events "startdate" }}
         {{ if .cfp_date_end }}
-          {{ if ge (dateFormat "2006-01-02" .cfp_date_end) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) }}
+          {{ if ge (dateFormat "2006-01-02" .cfp_date_end) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) }}
             <a href = "/events/{{ .name }}/" class = "footer-content">{{ .city }}</a><br />
           {{ end }} {{/* end: date is now or afterwards */}}
         {{ end }} {{/* end: if .cfp_date_end */}}

--- a/layouts/partials/future.html
+++ b/layouts/partials/future.html
@@ -1,6 +1,6 @@
 {{- range sort $.Site.Data.events "startdate" -}}
   {{- if .startdate -}}
-    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) -}}
+    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) -}}
       {{- if ne ($.Scratch.Get "year") (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year" (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year-displayed" "false" -}}

--- a/layouts/partials/map.html
+++ b/layouts/partials/map.html
@@ -28,7 +28,7 @@ function initialize() {
         {{ if .startdate }}
 
       // if the startdate is today or in the future
-          {{ if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) }}
+          {{ if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) }}
 
       // if the startdate month and enddate month are different, show both months
             {{ if ne (dateFormat "Jan" .startdate) (dateFormat "Jan" .enddate) }}

--- a/layouts/partials/past.html
+++ b/layouts/partials/past.html
@@ -11,7 +11,7 @@ Chomping .year has the nice effect of turning an int into string. -->
   {{ range $.Site.Data.events }}
   {{ if .startdate }}
   {{ $my_year := string ((dateFormat "2006" .enddate ))}}
-    {{ if and (eq $my_year (string $r_year)) ( lt (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")))  }}
+    {{ if and (eq $my_year (string $r_year)) ( lt (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)))  }}
       {{ $.Scratch.SetInMap "active_years" (print (chomp $my_year)) (print (chomp $my_year)) }}
       {{ $.Scratch.SetInMap (print (chomp $my_year)) .enddate (.name) }}
     {{ end }}

--- a/layouts/partials/speaking.html
+++ b/layouts/partials/speaking.html
@@ -6,7 +6,7 @@
   {{ range sort $.Site.Data.events "startdate" }}
 
   {{ if .cfp_date_end }}
-    {{ if ge (dateFormat "2006-01-02" .cfp_date_end) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) }}
+    {{ if ge (dateFormat "2006-01-02" .cfp_date_end) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) }}
       {{ $.Scratch.Add "events" "<tr><td><a href = '/events/" }}
       {{ $.Scratch.Add "events" .name }}
       {{ $.Scratch.Add "events" "/' class = 'speaking'>" }}
@@ -24,4 +24,3 @@
 
 
   {{ $.Scratch.Get "events" | safeHTML}}
-

--- a/layouts/partials/sponsors.html
+++ b/layouts/partials/sponsors.html
@@ -15,7 +15,7 @@
                 {{ $.Scratch.Add $level.id 1 }}
               {{ end }}
             {{ end }}
-            {{- if ( $e.startdate) or (ge (dateFormat "2006-01-02" $e.startdate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02"))) -}}
+            {{- if ( $e.startdate) or (ge (dateFormat "2006-01-02" $e.startdate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now))) -}}
               {{- if ne $e.sponsors_accepted "no" -}}
                 {{- if or (not $level.max) (lt ($.Scratch.Get $level.id) $level.max) -}}
                   <a href = "/events/{{ $e.name }}/sponsor" class="sponsor-cta">

--- a/layouts/section/events.rss.xml
+++ b/layouts/section/events.rss.xml
@@ -20,12 +20,12 @@
 <generator>Hugo -- gohugo.io</generator>
 {{- range sort $.Site.Data.events "startdate" -}}
   {{- if .startdate -}}
-    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) -}}
+    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) -}}
     <item>
       <title>devopsdays {{ .city }} {{ .year }}</title>
       <link>{{ $.Site.Params.weburl }}/events/{{ .name}}</link>
       <guid>{{ $.Site.Params.weburl }}/events/{{ .name}}</guid>
-      <pubDate>{{ dateFormat "Mon, 2 Jan 2006 15:04:05 -0700" $.Now }}</pubDate>
+      <pubDate>{{ dateFormat "Mon, 2 Jan 2006 15:04:05 -0700" now }}</pubDate>
       {{ if .description }}
         <description>{{.description | markdownify | htmlEscape}}</description>
       {{ else }}

--- a/layouts/section/speaking.rss.xml
+++ b/layouts/section/speaking.rss.xml
@@ -20,14 +20,14 @@
 <generator>Hugo -- gohugo.io</generator>
 {{- range sort $.Site.Data.events "startdate" -}}
   {{- if .startdate -}}
-    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) -}}
+    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) -}}
       {{ if .cfp_date_end }}
-        {{ if ge (dateFormat "2006-01-02" .cfp_date_end) (dateFormat "2006-01-02" ($.Now.Format "2006-01-02")) }}
+        {{ if ge (dateFormat "2006-01-02" .cfp_date_end) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) }}
         <item>
           <title>devopsdays {{ .city }} {{ .year }}</title>
           <link>{{ $.Site.Params.weburl }}/events/{{ .name}}</link>
           <guid>{{ $.Site.Params.weburl }}/events/{{ .name}}</guid>
-          <pubDate>{{ dateFormat "Mon, 2 Jan 2006 15:04:05 -0700" $.Now }}</pubDate>
+          <pubDate>{{ dateFormat "Mon, 2 Jan 2006 15:04:05 -0700" now }}</pubDate>
           {{ if .description }}
             <description>{{.description }}</description>
           {{ else }}


### PR DESCRIPTION
For some odd reason the deprecation message still appears when I run Hugo. I'll dig into this more, so please don't close #407 until I've investigated further.

The site builds and QA's fine with these changes.