### PR TITLE
Revert "Add check for legacy speaker files"

### DIFF
--- a/layouts/speakers/single.html
+++ b/layouts/speakers/single.html
@@ -59,25 +59,23 @@
 <!-- old stuff -->
 {{ if ne ($.Scratch.Get "speakers-exist") "true" }}
   {{ .Content }}
-  {{ if (where (readDir "data/speakers") "Name" (chomp $e.year))}}
-    {{ if (where (readDir (printf "data/speakers/%s" (chomp $e.year) )) "Name" $city_slug )}}
-      {{ range $fname, $s := index .Site.Data.speakers (print (chomp $e.year)) $city_slug }}
-        <div class="row">
-          <div class="col-md-12 col-lg-3">
-              <img alt = "{{ $s.name }}" src = "/events/{{ $event_slug }}/speakers/{{$fname}}.jpg" class="speakers-page old-speaker">
-          </div>
-          <div class= "col-md-12 col-lg-9 old-speaker-bio speakers-page">
-             <h3><a href="/events/{{ $event_slug }}/program/{{$fname}}">{{ $s.name }}</a></h3>
-             {{ if $s.twitter }} <a href="https://twitter.com/{{ $s.twitter }}">@{{ $s.twitter }}</a><br>{{ end }}
-             {{ if $s.website }}Website: <a href="{{ $s.website }}">{{ $s.website }}</a><br>{{ end }}
-             {{ if $s.pronouns }}Pronouns: {{ $s.pronouns }}{{ end }}
-           <br>
-           {{ $s.bio | markdownify }}
-        <hr>
-          </div>
-        </div>
-    {{ end }}
-  {{end }}
+
+  {{ range $fname, $s := index .Site.Data.speakers (print (chomp $e.year)) $city_slug }}
+<div class="row">
+  <div class="col-md-12 col-lg-3">
+      <img alt = "{{ $s.name }}" src = "/events/{{ $event_slug }}/speakers/{{$fname}}.jpg" class="speakers-page old-speaker">
+  </div>
+  <div class= "col-md-12 col-lg-9 old-speaker-bio speakers-page">
+     <h3><a href="/events/{{ $event_slug }}/program/{{$fname}}">{{ $s.name }}</a></h3>
+     {{ if $s.twitter }} <a href="https://twitter.com/{{ $s.twitter }}">@{{ $s.twitter }}</a><br>{{ end }}
+     {{ if $s.website }}Website: <a href="{{ $s.website }}">{{ $s.website }}</a><br>{{ end }}
+     {{ if $s.pronouns }}Pronouns: {{ $s.pronouns }}{{ end }}
+   <br>
+   {{ $s.bio | markdownify }}
+<hr>
+  </div>
+</div>
+
 {{ end }}
 
 <style>


### PR DESCRIPTION
Reverts devopsdays/devopsdays-theme#427

Unfortunately, this fix led to 2016's speaker pages being displayed as empty:

![screen shot 2017-03-25 at 3 37 56 pm](https://cloud.githubusercontent.com/assets/2104453/24326142/ea63f920-1175-11e7-8385-c4aac68692f0.png)

To prevent this revert from re-introducing its previous problems, I'm removing unused speaker.md pages in https://github.com/devopsdays/devopsdays-web/pull/2126 and preventing them from being created too early in https://github.com/devopsdays/devopsdays-web/pull/2125.