### PR TITLE
Fix event metadata

### DIFF
--- a/layouts/partials/events/event_metadata.html
+++ b/layouts/partials/events/event_metadata.html
@@ -3,19 +3,32 @@
 {{ $e :=  (index $.Site.Data.events $event_slug) }}
 {{/* end site data query */}}
 
-{{ $.Scratch.Add "url" $.Site.Params.weburl }}
+{{ $.Scratch.Set "url" $.Site.Params.weburl }}
 {{ $.Scratch.Add "url" "/events/"}}
 {{ $.Scratch.Add "url" $event_slug }}
+{{ $.Scratch.Set "contentdir" (printf "static/events/%s/" $event_slug) }}
+
+{{ $url := $.Scratch.Get "url" }}
+{{ $.Scratch.Set "image_url" ($.Scratch.Get "url") }}
+
+{{ if (where (readDir "static/events") "Name" $event_slug)}}
+
+
+  {{ if (where (readDir ($.Scratch.Get "contentdir")) "Name" "logo.jpg") }}
+    {{ $.Scratch.Add "image_url" "/logo.jpg" }}
+  {{ else }}
+    {{ $.Scratch.Add "image_url" "/logo.png" }}
+  {{ end }}
+
+{{ else }}
+    {{$.Scratch.Set "image_url" $.Site.Params.weburl }}
+    {{$.Scratch.Add "image_url" "/img/event-logo-square.jpg"}}
+{{ end}}
 
 
 
-{{- if $e.startdate -}}
+{{- if  and $e.startdate $e.location_address -}}
 
-
-  {{ $url := $.Scratch.Get "url" }}
-  {{ $.Scratch.Add "image_url" $url }}
-  {{ $.Scratch.Add "image_url" "/logo.png" }}
-  {{ $image_url := $.Scratch.Get "image_url" }}
   <script type="application/ld+json">
   {
     "@context": "http://schema.org",
@@ -28,8 +41,8 @@
     "name": "devopsdays {{ $e.city }} {{ $e.year }}",
     "startDate": "{{ $e.startdate }}",
     "endDate": "{{ $e.enddate }}",
-    "url": "{{ $url }}",
-    "image": "{{ $image_url }}",
+    "url": "{{ $.Scratch.Get "url" }}",
+    "image": "{{ $.Scratch.Get "image_url" }}",
     "location": {
       "@type": "Place",
       {{ if eq $e.city $e.location }}
@@ -37,13 +50,8 @@
       {{ else }}
         "name": "{{ $e.location }}, {{ $e.city }}",
       {{ end }}
-      {{ if $e.location_address }}
-        {{ if ne $e.location_address "" }}
-          "address": "{{ $e.location_address }}"
-        {{ else }}
-          "address": "{{ $e.coordinates }}"
-        {{ end }}
-      {{ end }}
+      "address": "{{ $e.location_address }}"
+
     }
   }
   </script>


### PR DESCRIPTION
Now it only displays structured metadata if there is an address set.

Fixes #445

Signed-off-by: Matt Stratton <matt.stratton@gmail.com>