### PR TITLE
Restore event twitter for old style events

### DIFF
--- a/layouts/shortcodes/event_twitter.html
+++ b/layouts/shortcodes/event_twitter.html
@@ -2,5 +2,9 @@
 {{ $event_slug := index $path 1 }}
 {{ $e :=  (index .Page.Site.Data.events $event_slug) }}
 
+{{ if $e.event_twitter}}
 <a href="https://twitter.com/{{ $e.event_twitter }}" class="twitter-follow-button" data-show-count="false">Follow @{{ $e.event_twitter }}</a>
+{{ else }}
+<a href="https://twitter.com/{{ index .Params 0 }}" class="twitter-follow-button" data-show-count="false">Follow @{{ index .Params 0 }}</a>
+{{ end }}
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>


### PR DESCRIPTION
Fixes https://github.com/devopsdays/devopsdays-theme/issues/479

Turns this:

![screen shot 2017-04-14 at 10 11 41 pm](https://cloud.githubusercontent.com/assets/2104453/25060370/098148f8-2161-11e7-9584-cb0f72ad936d.png)

Into this:

![screen shot 2017-04-14 at 10 12 26 pm](https://cloud.githubusercontent.com/assets/2104453/25060372/0e7baf6a-2161-11e7-8a8c-4cf667844fd4.png)
