### PR TITLE
Remove retina on images that don’t need it

### DIFF
--- a/gulp/tasks/copy-static-files.js
+++ b/gulp/tasks/copy-static-files.js
@@ -16,13 +16,19 @@ gulp.task('copy-css-maps', function() {
         .pipe(gulp.dest('dist/css'));
 })
 
+gulp.task('copy-other-images', function() {
+  return gulp.src(['public/**/*.png', 'public/**/*.jpg','public/**/*.jpeg',
+          '!public/favicon*', '!public/apple-icon*', '!public/android-icon*', '!public/ms-icon*', '!public/**/sharing.jpg', '!**/logo-square.*', '!public/img/sponsor/*.*', '!public/**/organizers/*.jpg'])
+      .pipe(gulp.dest('dist'));
+})
+
 // gulp.task('copy-static-files', function(callback) {
 //     runSequence('copy-misc-files', 'copy-fonts', 'copy-css-maps',
 //         callback
 //     )
 // })
 
-gulp.task('copy-static-files', ['copy-misc-files', 'copy-fonts', 'copy-css-maps'])
+gulp.task('copy-static-files', ['copy-misc-files', 'copy-fonts', 'copy-css-maps', 'copy-other-images'])
 
 
 // gulp.task('copy-images', function(callback) {

--- a/gulp/tasks/responsive-images.js
+++ b/gulp/tasks/responsive-images.js
@@ -8,7 +8,7 @@ runSequence = require('run-sequence');
 //     )
 // });
 
-gulp.task('responsive-images', ['responsive-images-logos', 'responsive-sponsor-images', 'responsive-organizer-images', 'responsive-images-remaining'])
+gulp.task('responsive-images', ['responsive-images-logos', 'responsive-sponsor-images', 'responsive-organizer-images'])
 
 
 


### PR DESCRIPTION
Since all it's doing is copying the files, we can do that much faster. This should shave 2-3 minutes off the build.