### PR TITLE
Adding vimeo as an option

### DIFF
--- a/layouts/talk/single.html
+++ b/layouts/talk/single.html
@@ -19,6 +19,22 @@
         {{- end -}}
     {{- end -}}
     <br />
+
+    {{- if isset .Params "vimeo" -}}
+      {{- if ne .Params.vimeo "" -}}
+        <div class="row">
+            <div class="col-md-12 vimeo-video">
+              <div class="embed-responsive embed-responsive-16by9">
+              <iframe class="embed-responsive-item" src="https://player.vimeo.com/video/{{ .Params.vimeo }}">
+              </iframe>
+              </div>
+            </div>
+          </div>
+        {{- end -}}
+    {{- end -}}
+
+
+
       <span class="talk-page content-text">
         {{ .Content }}
       </span>


### PR DESCRIPTION
As reported in https://github.com/devopsdays/devopsdays-theme/issues/542 it appears we didn't have code in the talk page to handle displaying vimeo. I've copied the youtube code and modified it to work with vimeo. In local testing this makes vimeo show up correctly.

![screen shot 2017-05-28 at 5 04 09 pm](https://cloud.githubusercontent.com/assets/2104453/26532532/85b576a4-43c8-11e7-8d16-9641b67751eb.png)

This will need to be merged and released before https://github.com/devopsdays/devopsdays-web/pull/2471 works correctly.

Fixes https://github.com/devopsdays/devopsdays-theme/issues/542
