### PR TITLE
Correcting default speaker image

### DIFF
--- a/layouts/talk/single.html
+++ b/layouts/talk/single.html
@@ -98,7 +98,7 @@
             <img src = "{{ (printf "events/%s/speakers/%s" $e.name .Params.image) | absURL }}" class="img-fluid"  alt="{{ $.Scratch.Get "speakername" }}"/><br />
           {{- end -}}
           {{- else -}}
-            <img src = "{{"img/speaker-default.png" | absURL }}" class="img-fluid"  alt="{{ $.Scratch.Get "speakername" }}"/><br />
+            <img src = "{{"img/speaker-default.jpg" | absURL }}" class="img-fluid"  alt="{{ $.Scratch.Get "speakername" }}"/><br />
         {{- end -}}
           <h4 class="talk-page"><a href = "{{ (printf "events/%s/speakers/%s" $e.name ($.Scratch.Get "speakername")) | absURL }}">
             {{ .Title }}


### PR DESCRIPTION
I noticed a broken image on the talk page when locally testing a speaker who doesn't have an image yet. 
![screen shot 2017-05-31 at 10 25 34 am](https://cloud.githubusercontent.com/assets/2104453/26639842/87a2942c-45eb-11e7-8562-d1853012bd04.png)

The speaker page, on the other hand, was fine.

![screen shot 2017-05-31 at 10 25 25 am](https://cloud.githubusercontent.com/assets/2104453/26639852/8d467056-45eb-11e7-8a08-355f57f1bb81.png)


This is the cause:
```
Bridgets-MacBook-Air:devopsdays-theme bridget$ grep -r speaker-default.png *
layouts/talk/single.html:            <img src = "{{"img/speaker-default.png" | absURL }}" class="img-fluid"  alt="{{ $.Scratch.Get "speakername" }}"/><br />
Bridgets-MacBook-Air:devopsdays-theme bridget$ find . -name speaker-default.png -print
Bridgets-MacBook-Air:devopsdays-theme bridget$
```

Fixes #547
