### PR TITLE
Remove requirement of no trailing dot

### DIFF
--- a/contributing.json
+++ b/contributing.json
@@ -4,7 +4,6 @@
     "subject_cannot_be_empty": true,
     "subject_must_be_longer_than": 4,
     "subject_must_be_shorter_than": 101,
-    "subject_must_not_end_with_dot": true,
 
     "body_cannot_be_empty": true,
     "body_must_include_verification_steps": false


### PR DESCRIPTION
I trip on this rule from time to time, and I don't think it's providing much value. I'm fine with being overruled on this.