### PR TITLE
Simplify retina 

### DIFF
--- a/gulp/tasks/responsive-images.js
+++ b/gulp/tasks/responsive-images.js
@@ -177,12 +177,10 @@ gulp.task('responsive-images-remaining', function() {
             '**/*.png': [{
                 width: '100%'
             }, {
-                width: '100%',
                 rename: {
                     suffix: '@2x'
                 }
             }, {
-                width: '100%',
                 rename: {
                     suffix: '@3x'
                 }
@@ -190,12 +188,10 @@ gulp.task('responsive-images-remaining', function() {
             '**/*.jpeg': [{
                 width: '100%'
             }, {
-                width: '100%',
                 rename: {
                     suffix: '@2x'
                 }
             }, {
-                width: '100%',
                 rename: {
                     suffix: '@3x'
                 }
@@ -203,12 +199,10 @@ gulp.task('responsive-images-remaining', function() {
             '**/*.jpg': [{
                 width: '100%'
             }, {
-                width: '100%',
                 rename: {
                     suffix: '@2x'
                 }
             }, {
-                width: '100%',
                 rename: {
                     suffix: '@3x'
                 }


### PR DESCRIPTION
This removes the 100% resizing of "images remaining" and simply does a resize. I'm hoping this makes it run a little faster, since it doesn't have to do any thinking.