### PR TITLE
Add shortcode for google forms

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -23,6 +23,8 @@
 &emsp;[Talk Page Fields](#talk-page-fields)   
 &emsp;[Speaker Page Fields](#speaker-page-fields)   
 &emsp;[Blog Post Fields](#blog-post-fields)   
+[Shortcodes](#shortcodes)   
+&emsp;[google_form](#google_form)   
 
 <!-- /MDTOC -->
 
@@ -277,3 +279,13 @@ Pages of the type `speaker` have a few additional frontmatter elements available
 | `Author`        | No       | The name of the person who wrote the blog post.                                                                                                                                     | "Matt Stratton"                                                                                                                                                                                                                                                                                      |
 | `title`         | Yes      | The title for the blog post.                                                                                                                                                        | "Chicago 2016 In Review"                                                                                                                                                                                                                                                                             |
 | `sharing_image` | No       | The image to use for social sharing. This is a path relative to the `static` directory.                                                                                             | "img/blog/chicago-2016-sharing.jpg"                                                                                                                                                                                                                                                                  |
+
+## Shortcodes
+
+Shortcodes can be used in any of your content (i.e., ".md" files. They provide easy ways to add content without having to write a lot of coding.)
+
+### google_form
+This shortcode allows for the embedding of a Google form on a page, in a manner that maintains the responsive, mobile-friendly design of the site. To use it, you only need the URL of your form (not the full embed code) and enter this on your page (substituting the proper URL):
+```
+{{< google_form "https://docs.google.com/forms/d/e/1FAIpQLScvv-ty_wEBlYkJaEC1OU0qqqbIHjf9JVa-Ptdo5TcHqz5EDA/viewform?usp=sf_link" >}}
+```

--- a/exampleSite/content/events/2017-ponyville/registration.md
+++ b/exampleSite/content/events/2017-ponyville/registration.md
@@ -2,9 +2,6 @@
 Title = "Registration"
 Type = "event"
 +++
+<h2>Registration</h2>
 
-<div style="width:100%; text-align:left;">
-
-Embed registration iframe/link/etc.
-</div></div>
-</div>
+{{< google_form "https://docs.google.com/forms/d/e/1FAIpQLScvv-ty_wEBlYkJaEC1OU0qqqbIHjf9JVa-Ptdo5TcHqz5EDA/viewform?usp=sf_link" >}}

--- a/layouts/shortcodes/google_form.html
+++ b/layouts/shortcodes/google_form.html
@@ -1,0 +1,3 @@
+<div style="width:100%; text-align:left;">
+<iframe src="{{ .Get 0 }}" width="100%" height="800px" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
+</div>


### PR DESCRIPTION
Fixes #230 

This adds a shortcode for embedding Google Forms, but maintaining the responsive layout on mobile.