### PR TITLE
Adds newline to talk page for #578.

### DIFF
--- a/layouts/talk/single.html
+++ b/layouts/talk/single.html
@@ -118,10 +118,10 @@
         <a href = "{{ (printf "events/%s/speakers/%s" $e.name ($.Scratch.Get "speakername")) | absURL}}">
         {{- if isset .Params "image" -}}
           {{- if ne .Params.image "" -}}
-            <img src = "{{ (printf "events/%s/speakers/%s" $e.name .Params.image) | absURL }}" class="img-fluid"  alt="{{ $.Scratch.Get "speakername" }}"/><br />
+            <img src = "{{ (printf "events/%s/speakers/%s" $e.name .Params.image) | absURL }}" class="img-fluid"  alt="{{ $.Scratch.Get "speakername" }}"/><br /><br />
           {{- end -}}
           {{- else -}}
-            <img src = "{{"img/speaker-default.jpg" | absURL }}" class="img-fluid"  alt="{{ $.Scratch.Get "speakername" }}"/><br />
+            <img src = "{{"img/speaker-default.jpg" | absURL }}" class="img-fluid"  alt="{{ $.Scratch.Get "speakername" }}"/><br /><br />
         {{- end -}}
           <h4 class="talk-page"><a href = "{{ (printf "events/%s/speakers/%s" $e.name ($.Scratch.Get "speakername")) | absURL }}">
             {{ .Title }}


### PR DESCRIPTION
Before:
<img width="298" alt="screen shot 2017-08-18 at 12 18 11 pm" src="https://user-images.githubusercontent.com/2104453/29469899-e28a89f0-840f-11e7-9209-4b8aee3aa4a7.png">

After:

<img width="281" alt="screen shot 2017-08-18 at 12 18 26 pm" src="https://user-images.githubusercontent.com/2104453/29469907-ea4e23cc-840f-11e7-9238-45476b10f5fe.png">

Fixes https://github.com/devopsdays/devopsdays-theme/issues/578

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/devopsdays/devopsdays-theme/587)
<!-- Reviewable:end -->
