### PR TITLE
Adds links to open spaces description in the program

### DIFF
--- a/layouts/program/single.html
+++ b/layouts/program/single.html
@@ -117,6 +117,11 @@
                                   {{- end -}}
                                 {{- end -}}
                               <!-- end ignite stuff here -->
+                              <!-- do open-space stuff here -->
+                              {{- else if (eq .type "open-space") -}}
+                                <a href="{{ "open-space-format/" | absURL }}">
+                                  {{ .title }}
+                                </a><br/>
                               {{- else -}}
                                 {{ .title }}
                             {{- end -}}


### PR DESCRIPTION
Fixes https://github.com/devopsdays/devopsdays-theme/issues/583

I wanted to spend some time learning how the DOD website works. I was looking over the issues list and found this easy one, so I fixed it.

## Before
![image](https://user-images.githubusercontent.com/736329/29856308-421af06c-8d52-11e7-81af-746a46e4dfc4.png)

## After
![image](https://user-images.githubusercontent.com/736329/29856314-4cdc4c12-8d52-11e7-9e4a-2e3d2320ab4a.png)


I'm not a massive fan of the blue text over the orange squares. Thoughts?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/devopsdays/devopsdays-theme/589)
<!-- Reviewable:end -->
