### PR TITLE
Prefer https for github and twitter

### DIFF
--- a/layouts/shortcodes/list_organizers.html
+++ b/layouts/shortcodes/list_organizers.html
@@ -26,7 +26,7 @@
               </p>
                 {{- if .twitter -}}
                   {{- $twitter := replace .twitter "@" "" -}}
-                  <a href="http://twitter.com/{{ $twitter }}" class="card-link"><i class="fa fa-twitter fa-2x" aria-hidden="true"></i></a>&nbsp;
+                  <a href="https://twitter.com/{{ $twitter }}" class="card-link"><i class="fa fa-twitter fa-2x" aria-hidden="true"></i></a>&nbsp;
                 {{- end -}}
                 {{- if .website -}}
                     <a href = "{{ .website }}"><i class="fa fa-home fa-2x" aria-hidden="true"></i></a>&nbsp;
@@ -38,7 +38,7 @@
                     <a href = "{{ .linkedin }}"><i class="fa fa-linkedin fa-2x" aria-hidden="true"></i></a>&nbsp;
                 {{- end -}}
                 {{- if .github -}}
-                    <a href = "http://github.com/{{ .github }}"><i class="fa fa-github fa-2x" aria-hidden="true"></i></a>&nbsp;
+                    <a href = "https://github.com/{{ .github }}"><i class="fa fa-github fa-2x" aria-hidden="true"></i></a>&nbsp;
                 {{- end -}}
                 {{- if .gitlab -}}
                     <a href = "https://gitlab.com/{{ .gitlab}}"><i class="fa fa-gitlab fa-2x" aria-hidden="true"></i></a>&nbsp;


### PR DESCRIPTION
This is a little nitpicky, but both GitHub and Twitter are served on `https`.
Linking to the `http` version causes a redirect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/devopsdays/devopsdays-theme/594)
<!-- Reviewable:end -->
