### PR TITLE
Add event_group

### DIFF
--- a/layouts/partials/welcome.html
+++ b/layouts/partials/welcome.html
@@ -79,13 +79,25 @@
         {{- if $e.city -}}
           {{- $.Scratch.Set "past-counter" 0 -}}
           {{- range sort $.Site.Data.events "startdate" -}}
-          {{- if .startdate -}} <!-- for some reason, it bails on the city Chicago, and also Paris -->
+          {{- if .startdate -}}
+
+            {{- if $e.event_group -}}
+              {{- if eq .event_group $e.event_group -}}
+                  {{- if and (ne .startdate $e.startdate) (ne ($.Scratch.Get "past-counter") 1 ) -}}
+                    <i>Other {{ $e.event_group }} Events</i><br />
+                    {{- $.Scratch.Set "past-counter" 1 -}}
+                  {{- end -}}
+                  {{- if ne .startdate $e.startdate -}}
+                    <a href = "{{ (printf "events/%s" .name) | absURL }}" class="welcome-page-masthead-link">{{ dateFormat "2006" .startdate }}</a> &nbsp;&nbsp;
+                  {{- end -}}
+              {{- end -}}
+            {{- else -}}
+
               {{- if eq (lower .city) (lower $e.city) -}}
                 {{- if and (ne .startdate $e.startdate) (ne ($.Scratch.Get "past-counter") 1 ) -}}
                   <i>Other {{ $e.city }} Events</i><br />
                   {{- $.Scratch.Set "past-counter" 1 -}}
                 {{- end -}}
-              {{- if eq (lower .city) (lower $e.city)}}
                 {{- if ne .startdate $e.startdate -}}
                   <a href = "{{ (printf "events/%s" .name) | absURL }}" class="welcome-page-masthead-link">{{ dateFormat "2006" .startdate }}</a> &nbsp;&nbsp;
                 {{- end -}}


### PR DESCRIPTION
What this does: if event_group set and there are multiple years, this now shows the "other events" that have the same event group.

This fixes https://github.com/devopsdays/devopsdays-theme/issues/61 assuming that event_group is properly set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/devopsdays/devopsdays-theme/614)
<!-- Reviewable:end -->
