### PR TITLE
Allow event_link to also pull event data

### DIFF
--- a/exampleSite/content/events/2017-ponyville/index.md
+++ b/exampleSite/content/events/2017-ponyville/index.md
@@ -8,4 +8,10 @@ Pivot paradigm sticky note agile grok unicorn waterfall is so 2000 and late resp
 
 # This is our thing!
 
+Tickets
+: {{< event_link url-key="registration_link" text="Register here!" >}}
+
+Location
+: {{< event_link text-key="location_address" page="location" >}}
+
 <img src ="/events/2017-ponyville/want.gif">

--- a/exampleSite/data/events/2017-ponyville.yml
+++ b/exampleSite/data/events/2017-ponyville.yml
@@ -13,7 +13,7 @@ registration_date_start: 2017-05-15
 registration_date_end: 2017-05-30
 registration_open: ""
 registration_closed: ""
-registration_link: ""
+registration_link: "https://www.example.com"
 coordinates: "41.882219, -87.640530"
 location: "Applejack House"
 location_address: "350 West Mart Center Drive, Chicago, IL 60654"

--- a/layouts/shortcodes/event_link.html
+++ b/layouts/shortcodes/event_link.html
@@ -1,2 +1,5 @@
 {{- $e := (index $.Site.Data.events (index (split ($.Page.Permalink | relURL) "/") 2)) -}}
-<a href = "{{ (printf "events/%s/%s" $e.name (.Get "page")) | absURL }}">{{ .Get "text" }}</a>
+{{- $url := index $e (.Get "url-key") | default (printf "events/%s/%s" $e.name (.Get "page")) | absURL -}}
+{{- $txt := index $e (.Get "text-key") | default (.Get "text") -}}
+
+<a href = "{{ $url }}">{{ $txt }}</a>


### PR DESCRIPTION
I'd like to extend the event_link shortcode to optionally pull from the event data - so that I can pull `cfp_link` and `registration_link` from my data file and link to them.

This PR adds two new properties to the shortcode, while preserving existing behaviour:
`url-key` - specifies a key whose value will be bond to the `href` of the link
`text-key` - specifies a key whose value will be bound to the text node of the link

If both `url-key` and `page` are specified, `url-key` will be preferred. Similarly, `text-key` will be preferred over `text`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/devopsdays/devopsdays-theme/617)
<!-- Reviewable:end -->
