### PR TITLE
adjust how speaker bios and attributes show up

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -42,6 +42,7 @@ The YYYY-CITY.yml file is the main configuration file for your event. This is wh
 | `event_twitter`  | String | Yes      | The twitter handle for your event such as "devopsdayschi" or "devopsdaysmsp". Exclude the "@" symbol. | "devopsdayschi"                               |
 | `description`    | String | No       | Overall description of your event. Quotation marks need to be escaped.                                | "It's time for more DevOpsDays at Ponyville!" |
 | `ga_tracking_id` | String | No       | If you have your own Google Analytics tracking ID, enter it here.                                     | "UA-74738648-1"                               |
+| `speakers_verbose` | String | No     | Set this to "true" if you want verbose speaker attributes (URLs visible).                             | "true"                                        |
 
 ### Date-related Fields
 All dates are in unquoted YYYY-MM-DD, like this: `variable: 2016-01-05`

--- a/layouts/speaker/single.html
+++ b/layouts/speaker/single.html
@@ -92,7 +92,7 @@
       {{- if ne .Params.pronouns "" -}}
         <a href = "https://pronoun.is/{{ .Params.pronouns }}"><i class="fa fa-user fa-2x" aria-hidden="true"></i>&nbsp;
       {{- if $e.speakers_verbose -}}
-        {{ .Params.pronouns }}<br />
+        https://pronoun.is/{{ .Params.pronouns }}<br />
       {{- end -}}
       </a>
       {{- end -}}

--- a/layouts/speaker/single.html
+++ b/layouts/speaker/single.html
@@ -11,36 +11,6 @@
   <div class = "col-md-4 offset-md-1">
     <span class="speaker-page content-text">
     {{ .Content }}
-    {{- if isset .Params "pronouns" -}}
-      {{- if ne .Params.pronouns "" -}}
-        My pronouns are {{ .Params.pronouns }}<br />
-      {{- end -}}
-    {{- end -}}
-    {{- if isset .Params "twitter" -}}
-      {{- if ne .Params.twitter "" -}}
-        <a href = "https://twitter.com/{{ .Params.twitter }}"><i class="fa fa-twitter fa-2x" aria-hidden="true"></i></a>&nbsp;
-      {{- end -}}
-    {{- end -}}
-    {{- if isset .Params "website" -}}
-      {{- if ne .Params.website "" -}}
-        <a href = "{{ .Params.website }}"><i class="fa fa-home fa-2x" aria-hidden="true"></i></a>&nbsp;
-      {{- end -}}
-    {{- end -}}
-    {{- if isset .Params "facebook" -}}
-      {{- if ne .Params.facebook "" -}}
-        <a href = "{{ .Params.facebook }}"><i class="fa fa-facebook-official fa-2x" aria-hidden="true"></i></a>&nbsp;
-      {{- end -}}
-    {{- end -}}
-    {{- if isset .Params "linkedin" -}}
-      {{- if ne .Params.linkedin "" -}}
-        <a href = "{{ .Params.linkedin }}"><i class="fa fa-linkedin fa-2x" aria-hidden="true"></i></a>&nbsp;
-      {{- end -}}
-    {{- end -}}
-    {{- if isset .Params "github" -}}
-      {{- if ne .Params.github "" -}}
-        <a href = "https://github.com/{{ .Params.github }}"><i class="fa fa-github fa-2x" aria-hidden="true"></i></a>&nbsp;
-      {{- end -}}
-    {{- end -}}
     </span>
 <div class="speaker-bio-talks">
      <h3>{{ .Title }} at {{ $e.city }} {{$e.year}}</h3>
@@ -72,6 +42,60 @@
       {{- end -}}
       {{- else -}}
         <img src = {{ "img/speaker-default.jpg" | absURL }} class="img-fluid"  alt="{{ .Title }}"/><br />
+    {{- end -}}
+    {{- if isset .Params "twitter" -}}
+      {{- if ne .Params.twitter "" -}}
+        <a href = "https://twitter.com/{{ .Params.twitter }}"><i class="fa fa-twitter fa-2x" aria-hidden="true"></i>
+      {{- if $e.speakers_verbose -}}
+        @{{ .Params.twitter }}<br />
+      {{- end -}}
+      </a>
+      {{- end -}}
+    {{- end -}}
+    {{- if isset .Params "website" -}}
+      {{- if ne .Params.website "" -}}
+        <a href = "{{ .Params.website }}"><i class="fa fa-home fa-2x" aria-hidden="true"></i>&nbsp;
+      {{- if $e.speakers_verbose -}}
+        {{ .Params.website }}<br />
+      {{- end -}}
+      </a>
+      {{- end -}}
+    {{- end -}}
+    {{- if isset .Params "facebook" -}}
+      {{- if ne .Params.facebook "" -}}
+        <a href = "{{ .Params.facebook }}"><i class="fa fa-facebook-official fa-2x" aria-hidden="true"></i>&nbsp;
+      {{- if $e.speakers_verbose -}}
+        {{ .Params.facebook }}<br />
+      {{- end -}}
+      </a>
+      {{- end -}}
+    {{- end -}}
+    {{- if isset .Params "linkedin" -}}
+      {{- if ne .Params.linkedin "" -}}
+        <a href = "{{ .Params.linkedin }}"><i class="fa fa-linkedin fa-2x" aria-hidden="true"></i>&nbsp;
+      {{- if $e.speakers_verbose -}}
+        {{ .Params.linkedin }}<br />
+      {{- end -}}
+      </a>
+      {{- end -}}
+    {{- end -}}
+    {{- if isset .Params "github" -}}
+      {{- if ne .Params.github "" -}}
+        <a href = "https://github.com/{{ .Params.github }}"><i class="fa fa-github fa-2x" aria-hidden="true"></i>&nbsp;
+      {{- if $e.speakers_verbose -}}
+        {{ .Params.github }}<br />
+      {{- end -}}
+      </a>
+      {{- end -}}
+    {{- end -}}
+    {{- if isset .Params "pronouns" -}}
+      {{- if ne .Params.pronouns "" -}}
+        <a href = "https://pronoun.is/{{ .Params.pronouns }}"><i class="fa fa-user fa-2x" aria-hidden="true"></i>&nbsp;
+      {{- if $e.speakers_verbose -}}
+        {{ .Params.pronouns }}<br />
+      {{- end -}}
+      </a>
+      {{- end -}}
     {{- end -}}
   </div>
 </div>

--- a/layouts/talk/single.html
+++ b/layouts/talk/single.html
@@ -128,9 +128,35 @@
           </a></h4>
         {{- if isset .Params "twitter" -}}
           {{- if ne .Params.twitter "" -}}
-            <a href = "https://twitter.com/{{ .Params.twitter }}"><i class="fa fa-twitter fa-2x" aria-hidden="true"></i></a><br />
+            <a href = "https://twitter.com/{{ .Params.twitter }}"><i class="fa fa-twitter fa-2x" aria-hidden="true"></i>&nbsp;</a>
           {{- end -}}
         {{- end -}}
+        {{- if isset .Params "website" -}}
+          {{- if ne .Params.website "" -}}
+            <a href = "{{ .Params.website }}"><i class="fa fa-home fa-2x" aria-hidden="true"></i>&nbsp;</a>
+          {{- end -}}
+        {{- end -}}
+    {{- if isset .Params "facebook" -}}
+      {{- if ne .Params.facebook "" -}}
+        <a href = "{{ .Params.facebook }}"><i class="fa fa-facebook-official fa-2x" aria-hidden="true"></i>&nbsp;</a>
+      {{- end -}}
+    {{- end -}}
+    {{- if isset .Params "linkedin" -}}
+      {{- if ne .Params.linkedin "" -}}
+        <a href = "{{ .Params.linkedin }}"><i class="fa fa-linkedin fa-2x" aria-hidden="true"></i>&nbsp;</a>
+      {{- end -}}
+    {{- end -}}
+    {{- if isset .Params "github" -}}
+      {{- if ne .Params.github "" -}}
+        <a href = "https://github.com/{{ .Params.github }}"><i class="fa fa-github fa-2x" aria-hidden="true"></i>&nbsp;</a>
+      {{- end -}}
+    {{- end -}}
+    {{- if isset .Params "pronouns" -}}
+      {{- if ne .Params.pronouns "" -}}
+        <a href = "https://pronoun.is/{{ .Params.pronouns }}"><i class="fa fa-user fa-2x" aria-hidden="true"></i>&nbsp;</a>
+      {{- end -}}
+    {{- end -}}
+    <br />
           <span class="talk-page content-text">
           {{- if ge (countrunes .Content ) 200 -}}
             {{ .Content | markdownify | truncate 200 " "}}<a href = "{{ .Permalink | absURL }}">...</a>

--- a/layouts/talk/single.html
+++ b/layouts/talk/single.html
@@ -128,10 +128,16 @@
           </a></h4>
         {{- if isset .Params "twitter" -}}
           {{- if ne .Params.twitter "" -}}
-            <a href = "https://twitter.com/{{ .Params.twitter }}"><i class="fa fa-twitter fa-2x" aria-hidden="true"></i></a>&nbsp;
+            <a href = "https://twitter.com/{{ .Params.twitter }}"><i class="fa fa-twitter fa-2x" aria-hidden="true"></i></a><br />
           {{- end -}}
         {{- end -}}
-          <span class="talk-page content-text">{{ .Content }}</span>
+          <span class="talk-page content-text">
+          {{- if ge (countrunes .Content ) 200 -}}
+            {{ .Content | markdownify | truncate 200 " "}}<a href = "{{ .Permalink | absURL }}">...</a>
+          {{- else -}}
+            {{ .Content | markdownify }}
+          {{- end -}}
+          </span>
         {{- end -}}
 
       {{- end -}}


### PR DESCRIPTION
This PR changes the display of speaker attributes to make them appear below the picture on the speaker page. It was discussed in https://github.com/devopsdays/devopsdays-theme/issues/612.
* Optionally, they can be configured to be more verbose (displaying link targets)
* Treats pronouns like all other attributes (with appropriate link to pronoun.is explainer site)

Before:

<img width="898" alt="screen shot 2018-01-06 at 7 37 16 pm" src="https://user-images.githubusercontent.com/2104453/34645796-65f4b614-f31c-11e7-964b-808055aee83d.png">

After (compact):

<img width="909" alt="screen shot 2018-01-06 at 7 39 37 pm" src="https://user-images.githubusercontent.com/2104453/34645798-7c8a7e36-f31c-11e7-81dd-83956b6c400e.png">


After (verbose):

<img width="883" alt="screen shot 2018-01-06 at 7 38 46 pm" src="https://user-images.githubusercontent.com/2104453/34645797-759c668e-f31c-11e7-886c-6bc7bb0a5161.png">



This PR also shortens the length limit of speaker bios on a talk page to send those interested to a speaker's detail page. The problem I'm trying to solve here is that speaker bios can be of arbitrary length and some are very long.  I'm interested in what @mattstratton thinks of this. (I can also split this out if desired. Also! I was considering https://github.com/devopsdays/devopsdays-theme/issues/582 and I'd be able to live with that if the talk detail page didn't use the verbose display, since that would be way too much clutter.)

Here's some visuals of what this looks like:

Before:

<img width="940" alt="screen shot 2018-01-06 at 8 03 34 pm" src="https://user-images.githubusercontent.com/2104453/34645812-b8feff5e-f31c-11e7-834e-f8d713f7bf74.png">


After:

<img width="980" alt="screen shot 2018-01-06 at 7 42 34 pm" src="https://user-images.githubusercontent.com/2104453/34645804-93275af6-f31c-11e7-891a-21ef1e391a35.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/devopsdays/devopsdays-theme/620)
<!-- Reviewable:end -->


Fixes #612 