### PR TITLE
Ensure that city names don't wrap

### DIFF
--- a/static/scss/custom.scss
+++ b/static/scss/custom.scss
@@ -63,6 +63,7 @@ b, strong {
 
 .nav-link {
   color: #0082AB;
+  white-space: nowrap;
 }
 
 .navbar-brand {


### PR DESCRIPTION
Such as "Cape Town"

I tested this by manually editing the minified CSS in the `devopsdays-web` and running that locally.

I wasn't sure how I could test compiling the SASS and and using the CSS from there.
I also don't know if this is the right solution for the problem.
Feel free to just close this if it's not right.

But it does solve the problem of wrapping cities:

**Before:**
![image](https://user-images.githubusercontent.com/736329/44277306-9112ad00-a24a-11e8-997a-49e984263a79.png)

**After:**
![image](https://user-images.githubusercontent.com/736329/44277315-9b34ab80-a24a-11e8-9fbc-c9c4a9decaa7.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/devopsdays/devopsdays-theme/637)
<!-- Reviewable:end -->
