### PR TITLE
bumps hugo version to match devopsdays-web site

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,10 +9,10 @@
   command = "bin/netlify.sh"
 
 [context.production.environment]
-   HUGO_VERSION = "0.31.1"
+   HUGO_VERSION = "0.46"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.31.1"
+  HUGO_VERSION = "0.46"
 
 [context.branch-deploy.environment]
-  HUGO_VERSION = "0.31.1"
+  HUGO_VERSION = "0.46"


### PR DESCRIPTION
Theme previews that we deploy via netlify should use the same version of Hugo as the devopsdays-web repo so that the previews will accurately reflect what will ultimately go to production. This PR may gate some fixes I'm working on for datetime handling.

ref https://github.com/devopsdays/devopsdays-web/commit/d23d2bee577943fc6c4d8f7a155e8a970f89af4b

cc @bridgetkromhout

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/devopsdays/devopsdays-theme/640)
<!-- Reviewable:end -->
