### PR TITLE
updates to use time comparisons for start/end dates

### DIFF
--- a/layouts/events/single.html
+++ b/layouts/events/single.html
@@ -12,7 +12,7 @@
   {{- $.Scratch.Set "close-tag" "false" -}}
 {{- range sort $.Site.Data.events "startdate" -}}
   {{- if .startdate -}}
-    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) -}}
+    {{- if ge (time .enddate) now -}}
       {{- if ne ($.Scratch.Get "year") (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year" (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year-displayed" "false" -}}
@@ -31,7 +31,7 @@
         {{- $.Scratch.Set "close-tag" "true" -}}
       {{- end -}}
       {{- if ne .startdate .enddate }}
-      {{- if eq (dateFormat "January" .startdate) (dateFormat "January" .enddate ) -}}
+      {{- if eq (time .startdate).Month (time .enddate).Month -}}
         <a href = "{{ (printf "events/%s" .name) | absURL }}" class = "events-page-event">
       {{ dateFormat "Jan 2" .startdate }} - {{ dateFormat "2" .enddate }}:
       {{ .city }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,7 +6,7 @@
     <div class="row">
         {{- range sort $.Site.Data.events "startdate" -}}
         {{- if .startdate -}}
-        {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) -}}
+        {{- if ge (time .enddate) now -}}
         {{- $.Scratch.Set "city" .city -}}
         {{- $.Scratch.Set "year" .year -}}
         {{- $.Scratch.Set "logo" "unset" -}}
@@ -24,7 +24,7 @@
                 {{- end -}}
                 <br/>
         {{- if ne .startdate .enddate -}}
-          {{- if eq (dateFormat "January" .startdate) (dateFormat "January" .enddate ) -}}
+          {{- if eq (time .startdate).Month (time .enddate).Month -}}
             <span class="homepage-grid-date">
             {{ dateFormat "Jan 2" .startdate }} - {{ dateFormat "2, 2006" .enddate }}<br />
             </span>

--- a/layouts/partials/events/cta.html
+++ b/layouts/partials/events/cta.html
@@ -21,7 +21,7 @@
     {{- else -}}
       {{- if $e.startdate -}}
         {{- if $e.registration_date_start -}}
-          {{- if and (ge (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) (dateFormat "2006-01-02" $e.registration_date_start)) (le (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) (dateFormat "2006-01-02" $e.registration_date_end)) -}}
+          {{- if and (ge now (time $e.registration_date_start)) (le now (time $e.registration_date_end)) -}}
             {{- if $e.registration_link -}}
               {{- if eq $e.registration_link "" -}}
                 {{- $.Scratch.Set "registration_link" ((printf "/events/%s/registration" $e.name) | absURL ) -}}

--- a/layouts/partials/future.html
+++ b/layouts/partials/future.html
@@ -1,6 +1,6 @@
 {{- range sort $.Site.Data.events "startdate" -}}
   {{- if .startdate -}}
-    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) -}}
+    {{- if ge (time .enddate) now -}}
       {{- if ne ($.Scratch.Get "year") (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year" (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year-displayed" "false" -}}
@@ -19,7 +19,7 @@
         {{- $.Scratch.Set "month-displayed" "true" -}}
       {{- end -}}
       {{- if ne .startdate .enddate }}
-        {{- if eq (dateFormat "January" .startdate) (dateFormat "January" .enddate ) -}}
+        {{- if eq (time .startdate).Month (time .enddate).Month -}}
           <a href = "{{ (printf "events/%s" .name ) | absURL }}" class = "left-nav-event">
         {{ dateFormat "Jan 2" .startdate }} - {{ dateFormat "2" .enddate }}:
         {{ .city }}

--- a/layouts/partials/map.html
+++ b/layouts/partials/map.html
@@ -21,10 +21,10 @@ function initialize() {
         {{ if .startdate }}
 
       // if the startdate is today or in the future
-          {{ if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) }}
+          {{ if ge (time .enddate) now }}
 
       // if the startdate month and enddate month are different, show both months
-            {{ if ne (dateFormat "Jan" .startdate) (dateFormat "Jan" .enddate) }}
+            {{ if ne (time .startdate).Month (time .enddate).Month }}
               ['{{ .city}}', {{ .coordinates | safeJS }}, '{{ dateFormat "Jan 2" .startdate }}-{{ dateFormat "Jan 2" .enddate }}', '/events/{{ .name }}'],
             {{ else }}
 

--- a/layouts/section/events.rss.xml
+++ b/layouts/section/events.rss.xml
@@ -20,7 +20,7 @@
 <generator>Hugo -- gohugo.io</generator>
 {{- range sort $.Site.Data.events "startdate" -}}
   {{- if .startdate -}}
-    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) -}}
+    {{- if ge (time .enddate) now -}}
     <item>
       {{- if eq .startdate .enddate -}}
         <title>devopsdays {{ .city }} {{ .year }} is coming! {{ dateFormat "Monday, January 2, 2006" .startdate }}</title>

--- a/layouts/section/speaking.rss.xml
+++ b/layouts/section/speaking.rss.xml
@@ -20,9 +20,9 @@
 <generator>Hugo -- gohugo.io</generator>
 {{- range sort $.Site.Data.events "startdate" -}}
   {{- if .startdate -}}
-    {{- if ge (dateFormat "2006-01-02" .enddate) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) -}}
+    {{- if ge (time .enddate) now -}}
       {{ if .cfp_date_end }}
-        {{ if ge (dateFormat "2006-01-02" .cfp_date_end) (dateFormat "2006-01-02" (dateFormat "2006-01-02" now)) }}
+        {{ if ge (time .cfp_date_end) now }}
         <item>
           <title>devopsdays {{ .city }} {{ .year }}</title>
           <link>{{ (printf "events/%s" .name) | absURL }}</link>


### PR DESCRIPTION
Many existing template partials take the current time (build time), cast it to a string, and compares it with the times from the event data (ex. start/end times) which are also being re-cast to strings here (twice!).

In order to allow us to use timezones as part of our comparison and not have the formatting involved in comparisons, use the `time` template function and directly compare against `now` without typecasting.

ref https://gohugo.io/functions/time/
ref https://gohugo.io/functions/now/

This PR does the same thing for start/endtime and registration times as #641.

---

There are still a few places where we're casting to strings, like in `partials/future.html` but in these cases we're starting with a string from the scratch space. So in other words we although we could do:

```
{{- if ne ($.Scratch.Get "year") (dateFormat "2006" .startdate) -}}
```

As:
```
{{- if ne (time ($.Scratch.Get "year")).Year (time .startdate).Year -}}
```

We end up _adding_ casts by doing that, which seems like it's not what we want here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/devopsdays/devopsdays-theme/642)
<!-- Reviewable:end -->
