### PR TITLE
improves template rendering performance

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -35,7 +35,7 @@
         {{- end -}}
         </div>
       </div>
-    {{- partial "footer.html" . -}}
+    {{- partialCached "footer.html" . -}}
     {{- partial "footer_scripts.html" . -}}
 </body>
 </html>

--- a/layouts/speaker/single.html
+++ b/layouts/speaker/single.html
@@ -16,8 +16,10 @@
      <h3>{{ .Title }} at {{ $e.city }} {{$e.year}}</h3>
           <ul class="list-group">
             {{- $.Scratch.Set "speaker" .File.BaseFileName -}}
-            {{- range where $.Site.Pages "Type" "talk" -}}
-              {{- if eq (index (split (.Permalink | relURL) "/") 2) $e.name -}}
+
+            {{- $p := $.Site.GetPage (printf "events/%s/program/%s" $e.name ($.Scratch.Get "speaker")) -}}
+            {{- if $p -}}
+              {{- with $p -}}
                 <!-- Now we can display stuff! -->
                 {{- range .Params.speakers -}}
                   {{- if eq . ($.Scratch.Get "speaker") -}}
@@ -28,12 +30,10 @@
                   <a href = "{{ .Permalink | absURL }}" class= "list-group-item list-group-item-action">{{ .Title }}</a>
                   {{ $.Scratch.Set "display" "false" }}
                 {{- end -}}
-              {{- end -}} <!-- end if eq $talk_slug $event_slug -->
-            {{- end -}} <!-- end range where $.Site.Pages "Type" "speaker" -->
+              {{- end -}} <!-- end with -->
+            {{- end -}} <!-- end if $p -->
           </ul>
           </div>
-      <!-- </div>
-    </div> -->
   </div>
   <div class = "col-md-3 offset-md-1">
     {{- if isset .Params "image" -}}

--- a/layouts/talk/single.html
+++ b/layouts/talk/single.html
@@ -112,11 +112,10 @@
 
   {{- range .Params.speakers -}}
     {{- $.Scratch.Set "speakername" . -}}
-    {{- range where $.Site.Pages "Type" "speaker" -}}
-      {{- if eq (index (split (.Permalink | relURL) "/") 2) $e.name -}}
-        {{- if eq .File.BaseFileName ($.Scratch.Get "speakername") -}}
-        <a href = "{{ (printf "events/%s/speakers/%s" $e.name ($.Scratch.Get "speakername")) | absURL}}">
-        {{- if isset .Params "image" -}}
+    {{- $p := $.Site.GetPage (printf "events/%s/speakers/%s" $e.name ($.Scratch.Get "speakername")) -}}
+    {{- if $p -}}
+    {{- with $p -}}
+       {{- if isset .Params "image" -}}
           {{- if ne .Params.image "" -}}
             <img src = "{{ (printf "events/%s/speakers/%s" $e.name .Params.image) | absURL }}" class="img-fluid"  alt="{{ $.Scratch.Get "speakername" }}"/><br /><br />
           {{- end -}}
@@ -167,8 +166,7 @@
         {{- end -}}
 
       {{- end -}}
-    {{- end -}} <!-- end range where $.Site.Pages "Type" "speaker" -->
-  {{- end -}}
+    {{- end -}}<!-- end with -->
   {{- else -}}<!-- now show the old stuff -->
   <h2 class="talk-page">Speaker</h2>
   {{- range $fname, $s := index .Site.Data.speakers (print (chomp $e.year)) (substr $e.name 5) -}}


### PR DESCRIPTION
For https://github.com/devopsdays/devopsdays-theme/issues/643

Reduce the overall rendering time by ~75% via the following:
- cache the entirely-static footer partial
- eliminate looping over all talks in speaker page
- eliminate looping over all speakers in talk page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/devopsdays/devopsdays-theme/644)
<!-- Reviewable:end -->
