### PR TITLE
ensures speaker's multiple talks in a single event display

### DIFF
--- a/layouts/speaker/single.html
+++ b/layouts/speaker/single.html
@@ -16,10 +16,7 @@
      <h3>{{ .Title }} at {{ $e.city }} {{$e.year}}</h3>
           <ul class="list-group">
             {{- $.Scratch.Set "speaker" .File.BaseFileName -}}
-
-            {{- $p := $.Site.GetPage (printf "events/%s/program/%s" $e.name ($.Scratch.Get "speaker")) -}}
-            {{- if $p -}}
-              {{- with $p -}}
+            {{ range where (where $.Site.Pages "Type" "talk") ".Dir" "=" (print "events/" $e.name "/program/") }}
                 <!-- Now we can display stuff! -->
                 {{- range .Params.speakers -}}
                   {{- if eq . ($.Scratch.Get "speaker") -}}
@@ -30,8 +27,7 @@
                   <a href = "{{ .Permalink | absURL }}" class= "list-group-item list-group-item-action">{{ .Title }}</a>
                   {{ $.Scratch.Set "display" "false" }}
                 {{- end -}}
-              {{- end -}} <!-- end with -->
-            {{- end -}} <!-- end if $p -->
+            {{- end -}} <!-- end range where -->
           </ul>
           </div>
   </div>


### PR DESCRIPTION
The performance improvement in #644 to the speaker page implicitly (and incorrectly) assumes that a speaker will give a single talk per event. Rather than using `.GetPage` which can return only a single
page, we can change the original call to `.Site.Pages` and get the correct behavior with at least some of the performance improvement.

This could be further improved if the program YAML included the event name, or if Hugo supported a "contains" or "startswith" operator in the where function.

Fixes https://github.com/devopsdays/devopsdays-theme/issues/643#issuecomment-421098679
Replaces https://github.com/devopsdays/devopsdays-web/pull/5404

I've tested this locally with the content in the main site, using the specific page called out in the issue (https://www.devopsdays.org/events/2018-portland/speakers/heidi-waterhouse/)

cc @bridgetkromhout

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/devopsdays/devopsdays-theme/658)
<!-- Reviewable:end -->
