### PR TITLE
Fix for #663 (dates displayed incorrectly)

### DIFF
--- a/layouts/partials/welcome.html
+++ b/layouts/partials/welcome.html
@@ -51,15 +51,19 @@
   <div class = "row">
     <div class="col-xs-12 col-md-8">
       <h1 class = "welcome-page">devopsdays {{$e.city}}</h1>
-        <span class="welcome-page-date">
-        {{- if $e.startdate -}}
-          {{- if ne $e.startdate $e.enddate }}
-            {{- dateFormat "January 2" $e.startdate -}} - {{- dateFormat "2, 2006" $e.enddate -}}
-          {{- else -}}
-            {{- dateFormat "January 2" $e.startdate -}}
-          {{- end -}}
-        {{ end }}
-        </span>
+
+    {{- if $e.startdate -}}
+      {{- if or (ne (time $e.startdate).Month (time $e.enddate).Month) (ne (time $e.startdate).Day (time $e.enddate).Day) -}}
+            <span class="welcome-page-date">
+            {{ dateFormat "January 2" $e.startdate }} - {{ dateFormat "2, 2006" $e.enddate }}<br />
+            </span>
+      {{- else -}}
+            <span class="welcome-page-date">
+          {{ dateFormat "January 2, 2006" $e.startdate }}<br />
+            </span>
+      {{- end -}}
+    {{- end -}}
+
         <br />
 
         {{- if $e.location -}}


### PR DESCRIPTION
This uses similar code to what we're now using on the front page (thanks to @tgross) to fix the dates displaying incorrectly on the welcome pages.

This fixes the comparison so that we're no longer comparing a date that now includes times and concluding that there are two different dates when there's really only one day being represented.

Fixes #663

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/devopsdays/devopsdays-theme/664)
<!-- Reviewable:end -->
