### PR TITLE
Images not resolving in early static events.

### DIFF
--- a/gulp/tasks/copy-static-files.js
+++ b/gulp/tasks/copy-static-files.js
@@ -22,7 +22,7 @@ gulp.task('copy-other-images', function() {
 })
 
 gulp.task('copy-old-images', function () {
-  return gulp.src(['public/events/2015*/**/', 'public/events/**/2016*/**/', '!**/*.html'])
+  return gulp.src(['public/events/2015*/**/', 'public/events/2016*/**/*', '!**/*.html'])
     .pipe(gulp.dest('dist/events'));
 });
 


### PR DESCRIPTION
This should fix #662 
>I noticed that https://www.devopsdays.org/events/2016-minneapolis/speakers/ had broken images. I looked into it, and it appears that we don't have images loading correctly in archived events that have been built for the live site. If I check locally, it still doesn't work because www.devopsdays.org is baked into the static files. If I look directly at the URL of a speaker image locally (not a link to it), it does still exist and redirect to where it lives in /static: http://localhost:1313/events/2016-minneapolis/speakers/aj-bowen.jpg

Looks like the gulp task which copied old images from /public/events/2016-minneapolis/speakers/ wasn't copying them across to /dist/events/2016/minneapolis/speakers/ causing the images to be broken.

I spun up an example of the 'fixed' example of this here: https://mystifying-goodall-173afa.netlify.com/events/2016-minneapolis/speakers/aj-bowen.jpg using the same problematic image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/devopsdays/devopsdays-theme/665)
<!-- Reviewable:end -->
