### PR TITLE
Add check for image files (organizer, speaker and sponsor) - Fix #573

### DIFF
--- a/layouts/partials/sponsors.html
+++ b/layouts/partials/sponsors.html
@@ -40,7 +40,14 @@
               {{- end -}}
 
               <div class = "col-lg-1 col-md-2 col-4">
-                <a href = "{{ $.Scratch.Get "SponsorURL" }}"><img src = "/img/sponsors/{{ .id }}.png" alt = "{{ $s.name }}" title = "{{ $s.name }}" class="img-fluid"></a>
+                <a href = "{{ $.Scratch.Get "SponsorURL" }}">
+                  {{ $imagefile := printf "static/img/sponsors/%s.png" .id }}
+                  {{ if fileExists $imagefile }}
+                  <img src = "/img/sponsors/{{ .id }}.png" alt = "{{ $s.name }}" title = "{{ $s.name }}" class="img-fluid">
+                  {{ else }}
+                    {{ errorf "%s not found" $imagefile }}
+                  {{ end }}
+                </a>
               </div>
             {{- end -}}
           {{- end -}}

--- a/layouts/shortcodes/list_organizers.html
+++ b/layouts/shortcodes/list_organizers.html
@@ -13,7 +13,12 @@
               {{ end }}
             </div>
             {{- if .image -}}
+            {{ $imagefile := printf "static/events/%s/organizers/%s" $e.name .image }}
+              {{ if (fileExists $imagefile) -}}
               <img class="card-img-top organizer-image" src="{{ (printf "events/%s/organizers/%s" $e.name .image) | absURL }}" alt="{{ .name }}">
+              {{- else }}
+                {{ errorf "%s not found" $imagefile }}
+              {{- end }}
             {{- end -}}
             <div class = "card-block">
               {{- if .employer -}}

--- a/layouts/speaker/single.html
+++ b/layouts/speaker/single.html
@@ -34,7 +34,12 @@
   <div class = "col-md-3 offset-md-1">
     {{- if isset .Params "image" -}}
       {{- if ne .Params.image "" -}}
+        {{ $imagefile := printf "static/events/%s/speakers/%s" $e.name .Params.image }}
+        {{ if fileExists $imagefile }}
         <img src = "{{ (printf "events/%s/speakers/%s" $e.name .Params.image) |absURL }}" class="img-fluid" alt="{{ .Title }}"/><br />
+        {{ else }}
+          {{ errorf "%s not found" $imagefile }}
+        {{ end }}
       {{- end -}}
       {{- else -}}
         <img src = {{ "img/speaker-default.jpg" | absURL }} class="img-fluid"  alt="{{ .Title }}"/><br />

--- a/layouts/speakers/single.html
+++ b/layouts/speakers/single.html
@@ -12,7 +12,12 @@
       <a href = "{{ .Permalink | absURL }}">
         {{- if isset .Params "image" -}}
           {{- if ne .Params.image "" -}}
+            {{ $imagefile := printf "static/events/%s/speakers/%s" $e.name .Params.image }}
+            {{ if fileExists $imagefile }}
             <img src = "{{ (printf "events/%s/speakers/%s" $e.name .Params.image) | absURL}}" class="speakers-page img-fluid" alt="{{ .Title }}"/><br />
+            {{ else }}
+              {{ errorf "%s not found" $imagefile }}
+            {{ end }}
           {{- end -}}
           {{- else -}}
             <img src = "{{"img/speaker-default.jpg" | absURL }}" class="speakers-page img-fluid"  alt="{{ .Title }}"/><br />


### PR DESCRIPTION
Please notice that this pr checks will likely fail, as my testing building was giving me A LOT of "image file missing" as you can see on the log below (you can also see that the return code wasn't 0)... but the building was working ok, just replacing the images with the same massage from the error when the image couldn't be found
```
Building sites … ERROR 2018/10/25 14:55:42 static/events/2018-cuba/organizers/enrique-carbonell.jpg not found
ERROR 2018/10/25 14:55:42 static/events/2018-cuba/organizers/manuel-oliver.jpg not found
ERROR 2018/10/25 14:55:42 static/events/2018-cuba/organizers/rudy-gevaert.jpg not found
ERROR 2018/10/25 14:55:42 static/events/2018-cuba/organizers/yadier-perdomo.jpg not found
ERROR 2018/10/25 14:55:50 static/events/2019-zurich/speakers/basil-brunner.jpg not found
ERROR 2018/10/25 14:55:50 static/events/2019-zurich/speakers/bernd-erk.jpg not found
ERROR 2018/10/25 14:55:50 static/events/2019-zurich/speakers/brian-christner.jpg not found
ERROR 2018/10/25 14:55:51 static/events/2019-zurich/speakers/christian-hirsig.jpg not found
ERROR 2018/10/25 14:55:51 static/events/2017-brasilia/organizers/gutocarvalho.jpg not found
ERROR 2018/10/25 14:55:51 static/events/2017-brasilia/organizers/tacianotres.jpg not found
ERROR 2018/10/25 14:55:51 static/events/2017-brasilia/organizers/laurosilveira.jpg not found
ERROR 2018/10/25 14:55:51 static/events/2017-brasilia/organizers/adrianovieira.jpg not found
ERROR 2018/10/25 14:55:52 static/events/2018-fortaleza/organizers/camila-mamede.jpeg not found
ERROR 2018/10/25 14:55:55 static/events/2019-zurich/speakers/franziska-buehler.jpg not found
ERROR 2018/10/25 14:55:55 static/events/2019-zurich/speakers/georgiana-gligor.jpg not found
ERROR 2018/10/25 14:55:55 static/events/2019-zurich/speakers/heinrich-hartmann.jpg not found
ERROR 2018/10/25 14:55:57 static/events/2019-zurich/speakers/kris-buytaert.jpg not found
ERROR 2018/10/25 14:55:59 static/events/2019-zurich/speakers/manuel-hutter.jpg not found
ERROR 2018/10/25 14:55:59 static/events/2019-zurich/speakers/marcin-niewiadomski.jpg not found
ERROR 2018/10/25 14:55:59 static/events/2019-zurich/speakers/maris-prabhakaran.jpg not found
ERROR 2018/10/25 14:55:59 static/events/2019-zurich/speakers/mathis-kretz.jpg not found
ERROR 2018/10/25 14:56:01 static/events/2019-zurich/speakers/paige-bernier.jpg not found
ERROR 2018/10/25 14:56:15 static/events/2019-zurich/speakers/rachael-byrne.jpg not found
ERROR 2018/10/25 14:56:15 static/events/2019-zurich/speakers/ramon-medrano-llamas.jpg not found
ERROR 2018/10/25 14:56:16 static/events/2019-zurich/speakers/serhat-can.jpg not found
ERROR 2018/10/25 14:56:17 static/events/2017-detroit/speakers/amin-yazdani.jpg not found
ERROR 2018/10/25 14:56:17 static/events/2017-detroit/speakers/barbara-bouldin.jpg not found
ERROR 2018/10/25 14:56:17 static/events/2017-detroit/speakers/chris-short.jpg not found
ERROR 2018/10/25 14:56:17 static/events/2017-detroit/speakers/david-laulusa.jpg not found
ERROR 2018/10/25 14:56:17 static/events/2017-detroit/speakers/don-ebben.jpg not found
ERROR 2018/10/25 14:56:17 static/events/2017-detroit/speakers/gene-kim.jpg not found
ERROR 2018/10/25 14:56:17 static/events/2017-detroit/speakers/john-willis.jpg not found
ERROR 2018/10/25 14:56:17 static/events/2017-detroit/speakers/julian-dunn.jpg not found
ERROR 2018/10/25 14:56:17 static/events/2017-edinburgh/speakers/paul-gillespie.jpg not found
ERROR 2018/10/25 14:56:17 static/events/2017-detroit/speakers/rebecca-fitzhugh.jpg not found
ERROR 2018/10/25 14:56:17 static/events/2017-detroit/speakers/sam-boyer.jpg not found
ERROR 2018/10/25 14:56:18 static/events/2018-copenhagen/speakers/allan-ebdrup.png not found
ERROR 2018/10/25 14:56:18 static/events/2018-copenhagen/speakers/anders-bruvik.png not found
ERROR 2018/10/25 14:56:18 static/events/2018-copenhagen/speakers/anders-truelsen.png not found
ERROR 2018/10/25 14:56:18 static/events/2018-copenhagen/speakers/aubrey-stearn.png not found
ERROR 2018/10/25 14:56:18 static/events/2018-copenhagen/speakers/boyan.png not found
ERROR 2018/10/25 14:56:18 static/events/2018-copenhagen/speakers/eduardo-piairo.png not found
ERROR 2018/10/25 14:56:18 static/events/2018-copenhagen/speakers/giulio-vian.png not found
ERROR 2018/10/25 14:56:18 static/events/2018-copenhagen/speakers/gloria-hornero.png not found
ERROR 2018/10/25 14:56:18 static/events/2018-copenhagen/speakers/greg-wunderle.png not found
ERROR 2018/10/25 14:56:18 static/events/2018-copenhagen/speakers/jeppe-andersen.png not found
ERROR 2018/10/25 14:56:18 static/events/2018-copenhagen/speakers/lars-bendix.png not found
ERROR 2018/10/25 14:56:18 static/events/2018-copenhagen/speakers/lars-kruse.png not found
ERROR 2018/10/25 14:56:18 static/events/2018-copenhagen/speakers/laszlo-fogas.png not found
ERROR 2018/10/25 14:56:18 static/events/2018-copenhagen/speakers/mandi-walls.png not found
ERROR 2018/10/25 14:56:18 static/events/2018-copenhagen/speakers/niels-harre.png not found
ERROR 2018/10/25 14:56:18 static/events/2018-copenhagen/speakers/thien-an-mac.png not found
ERROR 2018/10/25 14:56:18 static/events/2018-copenhagen/speakers/yves-hwang.png not found
ERROR 2018/10/25 14:56:18 static/events/2019-zurich/speakers/tanya-janca.jpg not found
ERROR 2018/10/25 14:56:18 static/events/2019-zurich/speakers/torben-hoeft.jpg not found
ERROR 2018/10/25 14:56:18 static/events/2019-zurich/speakers/nicole-becher.jpg not found
ERROR 2018/10/25 14:56:18 static/events/2019-zurich/speakers/philipp-krenn.jpg not found
ERROR 2018/10/25 14:56:30 static/events/2018-cuba/speakers/enrique-carbonell.jpg not found
ERROR 2018/10/25 14:56:41 static/events/2018-cuba/speakers/rudy-gevaert.jpg not found
ERROR 2018/10/25 14:56:44 static/events/2018-cuba/speakers/yadier-perdomo.jpg not found

                   |  EN   
+------------------+------+
  Pages            | 3852  
  Paginator pages  |    2  
  Non-page files   |   67  
  Static files     | 6271  
  Processed images |    0  
  Aliases          |  347  
  Sitemaps         |    1  
  Cleaned          |    0  

Total in 160807 ms
/src/devopsdays-theme/exampleSite # echo $?
255
/src/devopsdays-theme/exampleSite #
```