### PR TITLE
Fixes #682 Create a shortcode that allows the mailto field to be set

### DIFF
--- a/layouts/shortcodes/mailto_email.html
+++ b/layouts/shortcodes/mailto_email.html
@@ -1,5 +1,5 @@
 {{- $e := (index $.Site.Data.events (index (split ($.Page.Permalink | relURL) "/") 2)) -}}
-<script src="../../../js/devopsdays-min.js"></script>
+<script src="/js/devopsdays-min.js"></script>
 <script>
     $(window).one("load", function() {
         $("#share").jsSocials("shareOption", "email", "to", {{ $e.organizer_email }} );

--- a/layouts/shortcodes/mailto_email.html
+++ b/layouts/shortcodes/mailto_email.html
@@ -1,0 +1,7 @@
+{{- $e := (index $.Site.Data.events (index (split ($.Page.Permalink | relURL) "/") 2)) -}}
+<script src="../../../js/devopsdays-min.js"></script>
+<script>
+    $(window).one("load", function() {
+        $("#share").jsSocials("shareOption", "email", "to", {{ $e.organizer_email }} );
+    });
+</script>


### PR DESCRIPTION
This is a fix for issue #682 in which the `@` link on event welcome pages does not automatically fill out the `to` field. It creates a shortcode which will fill in the field with a passed in value `organizer_email`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/devopsdays/devopsdays-theme/683)
<!-- Reviewable:end -->
