### PR TITLE
Hotfix for sidebar

### DIFF
--- a/layouts/partials/future.html
+++ b/layouts/partials/future.html
@@ -1,6 +1,6 @@
 {{- range sort $.Site.Data.events "startdate" -}}
   {{- if .startdate -}}
-    {{- if ge (time .enddate) now -}}
+    {{- if ge (time .enddate) (now.AddDate 0 0 -1) -}}
       {{- if ne ($.Scratch.Get "year") (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year" (dateFormat "2006" .startdate) -}}
         {{- $.Scratch.Set "year-displayed" "false" -}}


### PR DESCRIPTION
I'm hotfixing this problem related to https://github.com/devopsdays/devopsdays-theme/issues/656 on the live site (https://github.com/devopsdays/devopsdays-web/pull/6180), but also putting it in the theme repo with this PR.

Before fix, notice how NYC is still present on the evening of its first day, but it's already scrolled off the sidebar on the left:

<img width="598" alt="screen shot 2019-01-24 at 10 31 44 pm" src="https://user-images.githubusercontent.com/2104453/51725588-b9d47500-2028-11e9-9a69-30f6e68e8f73.png">

After hotfix, it's back:
<img width="613" alt="screen shot 2019-01-24 at 10 50 51 pm" src="https://user-images.githubusercontent.com/2104453/51725955-8abf0300-202a-11e9-908a-9d53a8c3306a.png">

Thanks to @kmugrage for reminding me about this problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/devopsdays/devopsdays-theme/684)
<!-- Reviewable:end -->
